### PR TITLE
🔨 include local accounts in account list and stats

### DIFF
--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -39,8 +39,6 @@ export default {
 		// function to get all thunderbird accounts
 		getAccounts: async function () {
 			let accounts = await browser.accounts.list()
-			// only consider non local accounts
-			accounts = accounts.filter(a => a.type != 'none')
 			// calculate folder and message count and append to account object
 			let self = this
 			Promise.all(accounts.map(async a => {

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -156,8 +156,6 @@ export default {
 	methods: {
 		getAccounts: async function () {
 			let accounts = await browser.accounts.list()
-			// only consider non local accounts
-			accounts = accounts.filter(a => a.type != 'none')
 			// check if a specific account was given
 			let uri = window.location.search.substring(1)
 			let params = new URLSearchParams(uri)


### PR DESCRIPTION
# Don't exclude local accounts

## Requirements

* None

## Description of the Change

There is no reason for local accounts to be excluded. Deleted the filtering of account list for non local accounts.

## Benefits

Local accounts will be shown in the accounts list and therefor also get the stats

## Applicable Issues

Closing #13
