### PR TITLE
Visual improvements of chart layout

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -491,19 +491,39 @@ export default {
 // general
 html, body
 	margin 0
-	padding 0 1rem
+	padding 0
+body
 	font-family 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
 	background #202023
 	color #f9f9fa
 	font-weight 300
 	font-size 16px
+	overflow-x hidden
 
 // layout
+@media (min-width: 1601px)
+	#stats
+		max-width 1600px
+		.charts
+			grid-template-columns 1fr 1fr 1fr
+@media (max-width: 1600px)
+	#stats
+		max-width 1200px
+		.charts
+			grid-template-columns 1fr 1fr
+@media (max-width: 720px)
+	#stats
+		max-width 100%
+		.charts
+			grid-template-columns 1fr
+
+// content
 #stats
 	width 100%
 	height 100%
-	max-width 1200px
+	padding 0 2rem
 	margin 0 auto
+	box-sizing border-box
 
 	h1
 		display grid
@@ -548,7 +568,6 @@ html, body
 
 	.charts
 		display grid
-		grid-template-columns 1fr 1fr
 		column-gap 2rem
 		row-gap 1rem
 		.chart

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -501,12 +501,22 @@ body
 	overflow-x hidden
 
 // layout
-@media (min-width: 1601px)
+@media (min-width: 2501px)
 	#stats
-		max-width 1600px
+		max-width 2500px
+		.charts
+			grid-template-columns 1fr 1fr 1fr 1fr 1fr
+@media (max-width: 2500px)
+	#stats
+		max-width 2200px
+		.charts
+			grid-template-columns 1fr 1fr 1fr 1fr
+@media (max-width: 2000px)
+	#stats
+		max-width 1750px
 		.charts
 			grid-template-columns 1fr 1fr 1fr
-@media (max-width: 1600px)
+@media (max-width: 1500px)
 	#stats
 		max-width 1200px
 		.charts


### PR DESCRIPTION
## Description of the Change

Added a multicolumn layout depending on viewport width breaking points:

width > 2500px: 5 column layout
2000px < width <= 2500px: 4 column layout
1500px < width <= 2000px: 3 column layout
720px < width <= 1500px: 2 column layout
width <= 720px: 1 column layout

## Benefits

Available space on (ultra-)wide screens is not wasted but used to show all charts at first glance.

## Applicable Issues

Closes #9 
