### PR TITLE
🔨 min-width for chart resize issues

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -642,8 +642,6 @@ body
 		max-width 2500px
 		#chart-area-main
 			grid-template-columns repeat(6, 1fr)
-			.chart
-				min-width calc((2500px - (2rem * 7))  / 6)
 @media (max-width: 2500px)
 	#stats
 		max-width 2200px
@@ -666,8 +664,6 @@ body
 			grid-template-columns repeat(6, 1fr)
 		#chart-area-top
 			grid-template-columns 1fr 2fr
-			.chart
-				min-width 30vw
 @media (max-width: 960px)
 	#stats
 		.numbers
@@ -737,6 +733,7 @@ body
 			& > *
 				min-height 380px
 			.chart
+				min-width 0
 				h2
 					margin-bottom 0
 				p

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -642,6 +642,8 @@ body
 		max-width 2500px
 		#chart-area-main
 			grid-template-columns repeat(6, 1fr)
+			.chart
+				min-width calc((2500px - (2rem * 7))  / 6)
 @media (max-width: 2500px)
 	#stats
 		max-width 2200px
@@ -664,6 +666,8 @@ body
 			grid-template-columns repeat(6, 1fr)
 		#chart-area-top
 			grid-template-columns 1fr 2fr
+			.chart
+				min-width 30vw
 @media (max-width: 960px)
 	#stats
 		.numbers


### PR DESCRIPTION
solution based on this  [chartjs issue](https://github.com/chartjs/Chart.js/issues/5744)
solves #61 
2500px in calc formula is max-width of #stats
2rem is column-gap of .chart-area