### PR TITLE
🔨 exclude zero dates for date range calculation

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -298,7 +298,10 @@ export default {
 				this.numbers.received++
 				type = 'received'
 			}
-			if (m.date.getTime() < this.numbers.start.getTime()) this.numbers.start = m.date
+			// calculate starting date (= date of oldest email)
+			if (m.date && m.date.getTime() > 0 && m.date.getTime() < this.numbers.start.getTime()) {
+				this.numbers.start = m.date
+			}
 			// years
 			let y = m.date.getFullYear()
 			if (!(y in this.yearsData[type])) {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Harden the condition for taking a date from an email header as oldest date

## Benefits

Exclude malformed email headers where the date property is null.

## Applicable Issues

#91 
