### PR TITLE
➕ Add-on options

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -63,5 +63,23 @@
 			}
 		},
 		"starAndImprove": "Star and improve this project on <a href='{0}' target='_blank'>Github</a>"
+	},
+	"options": {
+		"message": "",
+		"switch": {
+			"on": "On",
+			"off": "Off"
+		},
+		"button": {
+			"save": "Save"
+		},
+		"darkMode": {
+			"label": "Dark Mode",
+			"description": ""
+		},
+		"localIdentities": {
+			"label": "Local Identities",
+			"description": ""
+		}
 	}
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -75,11 +75,11 @@
 		},
 		"darkMode": {
 			"label": "Dark Mode",
-			"description": ""
+			"description": "Switch between dark and light theme"
 		},
 		"localIdentities": {
 			"label": "Local Identities",
-			"description": ""
+			"description": "A comma seperated list of email addresses to recognize as 'sent from' for local accounts"
 		}
 	}
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,8 +1,8 @@
 {
-	"manifest_version": 2,
 	"name": "ThirdStats",
-	"description": "__MSG_extensionDescription__",
 	"version": "0.6.0",
+	"manifest_version": 2,
+	"description": "__MSG_extensionDescription__",
 	"author": "Andreas Müller",
 	"homepage_url": "https://github.com/devmount/third-stats",
 	"default_locale": "en",
@@ -17,10 +17,14 @@
 			"default_title": "ThirdStats",
 			"default_icon": "icon.svg"
 	},
+	"options_ui": {
+		"page": "options.html"
+	},
 	"permissions": [
 		"accountsRead",
 		"messagesRead",
-		"tabs"
+		"tabs",
+		"storage"
 	],
 	"icons": {
 			"64": "icon.svg",

--- a/public/options.html
+++ b/public/options.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<title>ThirdStats Options</title>
+	</head>
+	<body>
+		<noscript>
+			We're sorry but Thunderbird E-Mail Statistics doesn't work properly without JavaScript enabled.
+			Please enable it to continue.
+		</noscript>
+		<div id="options"></div>
+		<!-- built files will be auto injected -->
+	</body>
+</html>

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -60,7 +60,6 @@ export default {
 			let result = await messenger.storage.local.get('options')
 			this.addresses = result.options.addresses ? result.options.addresses : ''
 			this.dark = result.options.dark ? true : false
-			console.log(result.options);
 		},
 		// save current add-on settings
 		saveSettings: async function () {
@@ -70,7 +69,6 @@ export default {
 					dark: this.dark
 				}
 			})
-			console.log('saved');
 		}
 	}
 }

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -11,7 +11,10 @@
 	>
 		<div class='container p-1'>
 			<section class='entry'>
-				<label for='dark'>{{ $t('options.darkMode.label') }}</label>
+				<label for='dark'>
+					{{ $t('options.darkMode.label') }}
+					<span class="d-block text-gray text-small">{{ $t('options.darkMode.description') }}</span>
+				</label>
 				<div class='action'>
 					<label class='switch'>
 						<input type='checkbox' id='dark' v-model='dark' />
@@ -21,7 +24,10 @@
 				</div>
 			</section>
 			<section class='entry'>
-				<label for='dark'>{{ $t('options.localIdentities.label') }}</label>
+				<label for='dark'>
+					{{ $t('options.localIdentities.label') }}
+					<span class="d-block text-gray text-small">{{ $t('options.localIdentities.description') }}</span>
+				</label>
 				<div class='action'>
 					<textarea v-model='addresses' placeholder='hello@devmount.de, another@example.com'></textarea>
 				</div>
@@ -85,7 +91,11 @@ html, body
 
 	.entry
 		display: grid
-		grid-template-columns: 1fr 2fr
+		grid-template-columns: 2fr 3fr
+		column-gap: 1rem
 		margin-bottom: 1rem
+
+		.action
+			align-self: center
 
 </style>

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -11,25 +11,25 @@
 	>
 		<div class='container p-1'>
 			<section class='entry'>
-				<label for='dark'>Dark mode</label>
+				<label for='dark'>{{ $t('options.darkMode.label') }}</label>
 				<div class='action'>
 					<label class='switch'>
 						<input type='checkbox' id='dark' v-model='dark' />
-						<span class='switch-label' data-on='On' data-off='Off'></span> 
+						<span class='switch-label' :data-on='$t("options.switch.on")' :data-off='$t("options.switch.off")'></span> 
 						<span class='switch-handle'></span> 
 					</label>
 				</div>
 			</section>
 			<section class='entry'>
-				<label for='dark'>Local Identities</label>
+				<label for='dark'>{{ $t('options.localIdentities.label') }}</label>
 				<div class='action'>
-					<textarea v-model='addresses' placeholder='email1@example.com, email2@example.com'></textarea>
+					<textarea v-model='addresses' placeholder='hello@devmount.de, another@example.com'></textarea>
 				</div>
 			</section>
 			<section class='entry mt-5'>
 				<div></div>
-				<div class="action text-right">
-					<button @click='saveSettings'>Save</button>
+				<div class='action text-right'>
+					<button @click='saveSettings'>{{ $t('options.button.save') }}</button>
 				</div>
 			</section>
 		</div>

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -1,0 +1,91 @@
+<template>
+	<div
+		id='options'
+		:class='{
+			"dark": dark,
+			"light": !dark,
+			"text-normal": true,
+			"background-normal": dark,
+			"background-highlight-contrast": !dark,
+		}'
+	>
+		<div class='container p-1'>
+			<section class='entry'>
+				<label for='dark'>Dark mode</label>
+				<div class='action'>
+					<label class='switch'>
+						<input type='checkbox' id='dark' v-model='dark' />
+						<span class='switch-label' data-on='On' data-off='Off'></span> 
+						<span class='switch-handle'></span> 
+					</label>
+				</div>
+			</section>
+			<section class='entry'>
+				<label for='dark'>Local Identities</label>
+				<div class='action'>
+					<textarea v-model='addresses' placeholder='email1@example.com, email2@example.com'></textarea>
+				</div>
+			</section>
+			<section class='entry mt-5'>
+				<div></div>
+				<div class="action text-right">
+					<button @click='saveSettings'>Save</button>
+				</div>
+			</section>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: 'Options',
+	data () {
+		return {
+			addresses: '',
+			dark: true,
+		}
+	},
+	created () {
+		this.getSettings()
+	},
+	methods: {
+		// get all add-on settings
+		getSettings: async function () {
+			let result = await messenger.storage.local.get('options')
+			this.addresses = result.options.addresses ? result.options.addresses : ''
+			this.dark = result.options.dark ? true : false
+			console.log(result.options);
+		},
+		// save current add-on settings
+		saveSettings: async function () {
+			await messenger.storage.local.set({
+				options: {
+					addresses: this.addresses,
+					dark: this.dark
+				}
+			})
+			console.log('saved');
+		}
+	}
+}
+</script>
+
+<style lang='stylus'>
+@require "assets/global"
+
+// general
+html, body
+	min-height: 300px
+
+// layout
+#options
+	width 100%
+	height 100%
+	min-height: 300px
+
+	.entry
+		display: grid
+		grid-template-columns: 1fr 2fr
+		margin-bottom: 1rem
+
+</style>

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -238,16 +238,25 @@ export default {
 				week: {
 					start: 1
 				},
-				dark: true
+				dark: true,
+				localIdentities: []
 			}
 		}
 	},
 	created () {
 		this.reset()
+		this.getSettings()
 		this.getPreferences()
 		this.getAccounts()
 	},
 	methods: {
+		// get all add-on settings
+		getSettings: async function () {
+			let result = await messenger.storage.local.get('options')
+			this.preferences.localIdentities = result.options.addresses ? result.options.addresses.split(',') : ''
+			this.preferences.dark = result.options.dark ? true : false
+		},
+		// get legacy preferences
 		getPreferences: async function () {
 			let c = await messenger.LegacyPrefs.getUserPref("calendar.week.start")
 			this.preferences.week.start = c

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -253,7 +253,7 @@ export default {
 		// get all add-on settings
 		getSettings: async function () {
 			let result = await messenger.storage.local.get('options')
-			this.preferences.localIdentities = result.options.addresses ? result.options.addresses.split(',') : ''
+			this.preferences.localIdentities = result.options.addresses ? result.options.addresses.split(',').map(x => x.trim()) : []
 			this.preferences.dark = result.options.dark ? true : false
 		},
 		// get legacy preferences
@@ -274,7 +274,7 @@ export default {
 		processAccount: async function (id) {
 			this.waiting = true
 			let a = await messenger.accounts.get(id)
-			let identities = a.identities.map(i => i.email)
+			let identities = a.type != 'none' ? a.identities.map(i => i.email) : this.preferences.localIdentities
 			let folders = traverseAccount(a)
 			let self = this
 			await Promise.all(folders.map(async f => {

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -347,6 +347,7 @@ tooltip()
 	position: relative
 	&::after
 		border-radius: 3px
+		top: auto
 		bottom: 100%
 		content: attr(data-tooltip)
 		display: block
@@ -366,3 +367,10 @@ tooltip()
 		&::after
 			opacity: 1
 			transform: translate(-50%, -.4rem)
+	&.tooltip-bottom
+		&::after
+			bottom: auto
+			top: 100%
+		&:focus, &:hover
+			&::after
+				transform: translate(-50%, .4rem)

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -89,6 +89,10 @@ for m, c in mode
 			color: c.highlight !important
 		.background-normal, &.background-normal
 			background: c.back
+		.background-highlight, &.background-highlight
+			background: c.highlight
+		.background-highlight-contrast, &.background-highlight-contrast
+			background: c.secondary2
 		.background-modal, &.background-modal
 			background: c.gray3
 		.background-gray
@@ -126,6 +130,11 @@ for m, c in mode
 	margin-bottom: 6rem
 .m-0-auto
 	margin: 0 auto
+.p-1
+	padding: 1rem
+.py-1
+	padding-top: 1rem
+	padding-bottom: 1rem
 .pt-1
 	padding-top: 1rem
 .pt-2
@@ -189,10 +198,27 @@ for m, c in mode
 			box-shadow: 0 0 0 .35rem rgba(c.front, .1)
 
 // form
+button
+	appearance: none
+	border: none
+	border-radius: 2px
+	padding: 1rem 2rem
+	transition: background .2s
+	color: mode.dark.highlight
+	for m, c in mode
+		.{m} &
+			background: c.accent2
+		.{m} &:hover
+			background: darken(c.accent2, 20%)
+		.{m} &:active
+			background: lighten(c.accent2, 25%)
+		.{m} &:focus
+			box-shadow: 0 0 0 .25rem rgba(c.accent2, .2)
+
 select
 	appearance: none
 	border: none
-	border-radius: 4px
+	border-radius: 2px
 	color: inherit
 	padding: .5rem
 	outline: none
@@ -201,6 +227,108 @@ select
 			background: c.gray3
 			&.disabled
 				color: c.gray1
+
+textarea
+	appearance: none
+	border: solid 1px
+	border-radius: 2px
+	width: 100%
+	padding: .5rem
+	font-size: .9rem
+	for m, c in mode
+		.{m} &
+			background: c.back
+			color: c.front
+			if m is 'dark'
+				border-color: c.gray2
+			else
+				border-color: c.gray3
+		.{m} &:focus
+			border-color: c.accent2
+			box-shadow: 0 0 0 .25rem rgba(c.accent2, .2)
+
+.switch
+	padding: 0
+	position: relative
+	display: inline-block
+	vertical-align: top
+	width: 60px
+	height: h = 24px
+	border-radius: (h/2)
+	cursor: pointer
+	transition: all 0.2s ease
+	.switch-label
+		border: solid 1px
+		position: relative
+		display: block
+		height: inherit
+		font-size: 10px
+		text-transform: uppercase
+		border-radius: inherit
+		transition: inherit
+		&::before, &::after
+			position: absolute
+			top: 45%
+			transform: translateY(-50%)
+			transition: inherit
+		&::before
+			content: attr(data-off)
+			right: (h/4)
+		&::after
+			content: attr(data-on)
+			left: (h/4)
+			opacity: 0
+	.switch-handle
+		position: absolute
+		border-radius: 100%
+		top: 4px
+		left: 4px
+		width: (h*2/3)
+		height: (h*2/3)
+		transition: inherit
+	input
+		position: absolute
+		top: 0
+		left: 0
+		opacity: 0
+		&:checked
+			~ .switch-label
+				&::before
+					opacity: 0
+				&::after
+					opacity: 1
+			~ .switch-handle
+				left: 40px
+	for m, c in mode
+		.{m} &
+			.switch-label
+				border-color: c.gray3
+				if m is 'dark'
+					background: c.gray2
+				else
+					background: c.back
+				&::before
+					color: c.gray1
+				&::after
+					if m is 'dark'
+						color: c.highlight
+					else
+						color: c.secondary2
+			.switch-handle
+				if m is 'dark'
+					background: c.front
+				else
+					background: c.gray2
+			input
+				&:checked
+					~ .switch-label
+						background: c.accent2
+						border-color: c.accent2
+					~ .switch-handle
+						if m is 'dark'
+							background: c.highlight
+						else
+							background: c.secondary2
 
 // loader
 loader(size)

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,40 @@
+import Vue from 'vue'
+import Options from './Options.vue'
+
+// vue configuration
+Vue.config.productionTip = false
+Vue.config.devtools = false
+
+// internationalization
+import VueI18n from 'vue-i18n'
+Vue.use(VueI18n)
+let messages = {
+	'ca':    require('../public/_locales/ca/messages.json'),    // Catalan
+	'cs':    require('../public/_locales/cs/messages.json'),    // Czech
+	'de':    require('../public/_locales/de/messages.json'),    // German
+	'en':    require('../public/_locales/en/messages.json'),    // English
+	'es':    require('../public/_locales/es/messages.json'),    // Spanish
+	'fr':    require('../public/_locales/fr/messages.json'),    // French
+	'gl':    require('../public/_locales/gl/messages.json'),    // Galician
+	'hi':    require('../public/_locales/hi/messages.json'),    // Hindi
+	'it':    require('../public/_locales/it/messages.json'),    // Italian
+	'ja':    require('../public/_locales/ja/messages.json'),    // Japanese
+	'pl':    require('../public/_locales/pl/messages.json'),    // Polish
+	'pt':    require('../public/_locales/pt/messages.json'),    // Portuguese
+	'ru':    require('../public/_locales/ru/messages.json'),    // Russian
+	'sv':    require('../public/_locales/sv/messages.json'),    // Swedish
+	'th':    require('../public/_locales/th/messages.json'),    // Thai
+	'tr':    require('../public/_locales/tr/messages.json'),    // Turkish
+	'zh-cn': require('../public/_locales/zh-cn/messages.json'), // Simplified Chinese
+	'zh-tw': require('../public/_locales/zh-tw/messages.json'), // Traditional Chinese
+}
+const i18n = new VueI18n({
+	locale: messenger.i18n.getUILanguage(),
+	fallbackLocale: 'en',
+	messages,
+})
+
+new Vue({
+	i18n,
+	render: h => h(Options),
+}).$mount('#options')

--- a/vue.config.js
+++ b/vue.config.js
@@ -13,6 +13,10 @@ module.exports = {
 			entry: './src/stats.js',
 			template: './public/stats.html'
 		},
+		options: {
+			entry: './src/options.js',
+			template: './public/options.html'
+		},
 	},
 	configureWebpack: {
 		plugins: [


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This PR implements add-on specific options (within a 5MB threshold):

- Dark mode flag to keep the preferred theme mode
- Local identities for recognition of sent mails in local accounts

## Benefits

The options above and the ability for future options

## Applicable Issues

#86 
