### PR TITLE
💚 use more meaningful dashboard icon

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -4,6 +4,7 @@
   },
   "popup": {
     "account": "Account | Accounts",
+    "linkDescription": "Open all stats in new tab",
     "messagesInFolder": "{0} messages in {1} folders",
     "message": "-"
   },

--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -1,15 +1,17 @@
 <template>
 	<div id='popup'>
 		<div class='container pt-1'>
-			<h3 @click.prevent="openTab(0)" class="text-hover-accent2 cursor-pointer">
+			<h3
+				@click.prevent="openTab(0)"
+				class="text-hover-accent2 cursor-pointer tooltip tooltip-bottom"
+				:data-tooltip='$t("popup.linkDescription")'
+			>
 				<span class='mr-1'>{{ accounts.length }} {{ $tc('popup.account', accounts.length) }}</span>
 				<span v-if='waiting' class='dark loading'></span>
 				<svg class='icon icon-thin icon-small ml-auto' viewBox="0 0 24 24">
 					<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-					<rect x="4" y="4" width="6" height="6" rx="1" />
-					<rect x="14" y="4" width="6" height="6" rx="1" />
-					<rect x="4" y="14" width="6" height="6" rx="1" />
-					<rect x="14" y="14" width="6" height="6" rx="1" />
+					<line x1="4" y1="19" x2="20" y2="19" />
+					<polyline points="4 15 8 9 12 11 16 6 20 10 20 15 4 15" />
 				</svg>
 			</h3>
 			<div class='accounts'>

--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -1,14 +1,15 @@
 <template>
 	<div id='popup'>
 		<div class='container pt-1'>
-			<div v-if='waiting' class='dark loading'></div>
 			<h3 @click.prevent="openTab(0)" class="text-hover-accent2 cursor-pointer">
 				<span class='mr-1'>{{ accounts.length }} {{ $tc('popup.account', accounts.length) }}</span>
-				<svg class='icon icon-thin icon-small' viewBox="0 0 24 24">
+				<span v-if='waiting' class='dark loading'></span>
+				<svg class='icon icon-thin icon-small ml-auto' viewBox="0 0 24 24">
 					<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-					<path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5" />
-					<line x1="10" y1="14" x2="20" y2="4" />
-					<polyline points="15 4 20 4 20 9" />
+					<rect x="4" y="4" width="6" height="6" rx="1" />
+					<rect x="14" y="4" width="6" height="6" rx="1" />
+					<rect x="4" y="14" width="6" height="6" rx="1" />
+					<rect x="14" y="14" width="6" height="6" rx="1" />
 				</svg>
 			</h3>
 			<div class='accounts'>
@@ -95,34 +96,33 @@ export default {
 
 // general
 html, body
-	min-width 300px
-	overflow hidden
+	min-width: 300px
+	overflow: hidden
 
 // layout
 #popup
-	width 100%
-	height 100%
+	width: 100%
+	height: 100%
 
 	.container
-		padding-left 20px
-		padding-right 20px
+		padding-left: 20px
+		padding-right: 20px
 		h3
-			margin-top 0
-			font-weight 300
-			font-size 20px
-			transition color .2s
-			&>*
-				vertical-align middle
+			margin-top: 0
+			font-weight: 300
+			font-size: 20px
+			transition: color .2s
+			display: flex
+			flex-wrap: nowrap
 		.loading
-			float right
 			loader 16px
 		.accounts
-			display flex
-			flex-direction column
+			display: flex
+			flex-direction: column
 			& > div
-				padding 8px 10px
-				margin-bottom 20px
-				border-radius 4px
-				transition all .2s
+				padding: 8px 10px
+				margin-bottom: 20px
+				border-radius: 4px
+				transition: all .2s
 
 </style>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Use a more meaningful dashboard icon in the popup, move the spinner to the accounts label (semantically more correct)

## Benefits

More clean and more intuitive UX
![image](https://user-images.githubusercontent.com/5441654/99759282-cc1f7d00-2af2-11eb-8feb-26388c85377e.png)

And an additional tooltip on mouseover to explain the action
![image](https://user-images.githubusercontent.com/5441654/99760194-70a1bf00-2af3-11eb-8bf7-fdc675df03bf.png)

## Applicable Issues

Closes #129 
