### PR TITLE
➕ implement stats cache, revamp options

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -121,7 +121,9 @@
     },
     "clearCache": {
       "label": "Clear Cache",
-      "description": "Remove all cached stats data from all accounts. Will be rebuild on opening the stats page again."
+      "description": "Remove all cached stats data from all accounts. Will be rebuild on opening the stats page again.",
+      "empty": "Cache is empty",
+      "size": "Cache size is {0}"
     },
     "note": {
       "title": "Note",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -90,12 +90,18 @@
     "message": "-"
   },
   "options": {
+    "headings": {
+      "appearance": "Appearance & Experience",
+      "stats": "Charts & Figures",
+      "storage": "Storage & Cache"
+    },
     "switch": {
       "on": "On",
       "off": "Off"
     },
     "button": {
-      "save": "Save"
+      "save": "Save",
+      "clearCache": "Clear Cache"
     },
     "darkMode": {
       "label": "Dark Mode",
@@ -103,11 +109,23 @@
     },
     "localIdentities": {
       "label": "Local Identities",
-      "description": "A comma separated list of email addresses to recognize as 'sent from' for local accounts"
+      "description": "A list of email addresses to recognize as 'sent from' for local accounts"
     },
     "startOfWeek": {
       "label": "Start the Week on",
       "description": "Custom start of week for all weekday related charts"
+    },
+    "cache": {
+      "label": "Activate Cache",
+      "description": "Enable caching system for faster display of already processed stats data."
+    },
+    "clearCache": {
+      "label": "Clear Cache",
+      "description": "Remove all cached stats data from all accounts. Will be rebuild on opening the stats page again."
+    },
+    "note": {
+      "title": "Note",
+      "reloadStatsPage": "Options are automatically saved. If the stats page is already open, you have to reopen or reload it for changes to be applied."
     },
     "message": "-"
   }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -79,7 +79,8 @@
     },
     "tooltips": {
       "expand": "Expand chart area",
-      "shrink": "Shrink chart area"
+      "shrink": "Shrink chart area",
+      "refresh": "Refresh data"
     },
     "abbreviations": {
       "calendarWeek": "W",

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -2,14 +2,16 @@
 	<div
 		id='options'
 		:class='{
-			"dark": dark,
-			"light": !dark,
+			"dark": options.dark,
+			"light": !options.dark,
 			"text-normal": true,
-			"background-normal": dark,
-			"background-highlight-contrast": !dark,
+			"background-normal": options.dark,
+			"background-highlight-contrast": !options.dark,
 		}'
 	>
 		<div class='container p-1'>
+			<!-- section related to ThirdStats appearance and UI -->
+			<h2>{{ $t('options.headings.appearance') }}</h2>
 			<!-- option: dark -->
 			<section class='entry'>
 				<label for='dark'>
@@ -18,41 +20,86 @@
 				</label>
 				<div class='action'>
 					<label class='switch'>
-						<input type='checkbox' id='dark' v-model='dark' />
+						<input type='checkbox' id='dark' v-model='options.dark' />
 						<span class='switch-label' :data-on='$t("options.switch.on")' :data-off='$t("options.switch.off")'></span> 
 						<span class='switch-handle'></span> 
 					</label>
 				</div>
 			</section>
+			<!-- section related to the stats page -->
+			<h2 class='mt-3'>{{ $t('options.headings.stats') }}</h2>
 			<!-- option: addresses -->
 			<section class='entry'>
 				<label for='local'>
 					{{ $t('options.localIdentities.label') }}
-					<span class="d-block text-gray text-small">{{ $t('options.localIdentities.description') }}</span>
+					<span class='d-block text-gray text-small'>{{ $t('options.localIdentities.description') }}</span>
 				</label>
 				<div class='action'>
-					<textarea v-model='addresses' placeholder='hello@devmount.de, another@example.com' id='local'></textarea>
+					<div class="d-flex">
+						<input  class='flex-grow' type='email' v-model='input.address' placeholder='hello@devmount.de' id='local' />
+						<button @click='addAddress' class='button-inline'>
+							<svg class="icon icon-small d-block m-0-auto" viewBox="0 0 24 24">
+								<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+								<line x1="12" y1="5" x2="12" y2="19" />
+								<line x1="5" y1="12" x2="19" y2="12" />
+							</svg>
+						</button>
+					</div>
+					<div>
+						<span class='tag text-tiny' v-for='a in addressList'>
+							{{ a }}
+							<svg @click='removeAddress(a)' class="icon icon-bold icon-text cursor-pointer" viewBox="0 0 24 24">
+								<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+								<line x1="18" y1="6" x2="6" y2="18" />
+								<line x1="6" y1="6" x2="18" y2="18" />
+							</svg>
+						</span>
+					</div>
 				</div>
 			</section>
 			<!-- option: startOfWeek -->
 			<section class='entry'>
 				<label for='start'>
 					{{ $t('options.startOfWeek.label') }}
-					<span class="d-block text-gray text-small">{{ $t('options.startOfWeek.description') }}</span>
+					<span class='d-block text-gray text-small'>{{ $t('options.startOfWeek.description') }}</span>
 				</label>
-				<div class='action'>
-					<select v-model='startOfWeek' id='start'>
+				<div class='action d-flex'>
+					<select class='flex-grow' v-model='options.startOfWeek' id='start'>
 						<option v-for='(name, pos) in weekdayNames' :key='pos' :value='pos'>{{ name }}</option>
 					</select>
 				</div>
 			</section>
-			<!-- save options -->
-			<section class='entry mt-5'>
-				<div></div>
-				<div class='action text-right'>
-					<button @click='saveSettings'>{{ $t('options.button.save') }}</button>
+			<!-- section related to store processed data -->
+			<h2 class='mt-3'>{{ $t('options.headings.storage') }}</h2>
+			<!-- option: cache -->
+			<section class='entry'>
+				<label for='cache'>
+					{{ $t('options.cache.label') }}
+					<span class="d-block text-gray text-small">{{ $t('options.cache.description') }}</span>
+				</label>
+				<div class='action'>
+					<label class='switch'>
+						<input type='checkbox' id='cache' v-model='options.cache' />
+						<span class='switch-label' :data-on='$t("options.switch.on")' :data-off='$t("options.switch.off")'></span> 
+						<span class='switch-handle'></span> 
+					</label>
 				</div>
 			</section>
+			<!-- action: clear cache -->
+			<section class='entry'>
+				<label>
+					{{ $t('options.clearCache.label') }}
+					<span class="d-block text-gray text-small">{{ $t('options.clearCache.description') }}</span>
+				</label>
+				<div class='action'>
+					<button @click='clearCache'>{{ $t('options.button.clearCache') }}</button>
+				</div>
+			</section>
+			<hr class='my-3' />
+			<footer class='text-gray'>
+				<h4 class='text-thin mb-05'>{{ $t('options.note.title') }}</h4>
+				<div class='text-tiny'>{{ $t('options.note.reloadStatsPage') }}</div>
+			</footer>
 		</div>
 	</div>
 </template>
@@ -62,9 +109,15 @@ export default {
 	name: 'Options',
 	data () {
 		return {
-			dark: true,
-			addresses: '',
-			startOfWeek: 0,
+			input: {
+				address: '',
+			},
+			options: {
+				dark: true,
+				addresses: '',
+				startOfWeek: 0,
+				cache: true,
+			}
 		}
 	},
 	created () {
@@ -77,18 +130,55 @@ export default {
 			let result = await messenger.storage.local.get('options')
 		// only load options if they have been set, otherwise default settings will be kept
 			if (result && result.options) {
-				this.addresses = result.options.addresses ? result.options.addresses : ''
-				this.dark = result.options.dark ? true : false
-				this.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
+				this.options.dark = result.options.dark ? true : false
+				this.options.addresses = result.options.addresses ? result.options.addresses : ''
+				this.options.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
+				this.options.cache = result.options.cache ? true : false
 			}
 		},
-		// save current add-on settings
-		saveSettings: async function () {
+		// add configured email address to list of addresses and save
+		addAddress: async function () {
+			if (this.input.address) {
+				let addresses = this.options.addresses ? this.options.addresses + ',' : ''
+				addresses += this.input.address
+				await messenger.storage.local.set({
+					options: {
+						dark: this.options.dark,
+						addresses: addresses,
+						startOfWeek: this.options.startOfWeek,
+						cache: this.options.cache,
+					}
+				})
+				this.options.addresses = addresses
+				this.input.address = ''
+			}
+		},
+		// remove given email address from list of addresses and save
+		removeAddress: async function (address) {
+			let addresses = this.options.addresses.replace(address, '')
+			addresses = addresses.replace(/,,/g, ',')
+			addresses = addresses.replace(/^,+|,+$/g, '');
 			await messenger.storage.local.set({
 				options: {
-					addresses: this.addresses,
-					dark: this.dark,
-					startOfWeek: this.startOfWeek,
+					dark: this.options.dark,
+					addresses: addresses,
+					startOfWeek: this.options.startOfWeek,
+					cache: this.options.cache,
+				}
+			})
+			this.options.addresses = addresses
+		},
+		// clear all cached stats entries
+		clearCache: async function () {
+			// clear whole local storage
+			await messenger.storage.local.clear()
+			// restore options
+			await messenger.storage.local.set({
+				options: {
+					dark: this.options.dark,
+					addresses: this.options.addresses,
+					startOfWeek: this.options.startOfWeek,
+					cache: this.options.cache,
 				}
 			})
 		}
@@ -102,6 +192,42 @@ export default {
 				names.push(d.toLocaleDateString(this.$i18n.locale, { weekday: 'long' }))
 			}
 			return names
+		},
+		// array of email addresses configured for local account identities
+		addressList () {
+			return this.options.addresses ? this.options.addresses.split(',') : []
+		}
+	},
+	watch: {
+		'options.dark': async function (val) {
+			await messenger.storage.local.set({
+				options: {
+					dark: val,
+					addresses: this.options.addresses,
+					startOfWeek: this.options.startOfWeek,
+					cache: this.options.cache,
+				}
+			})
+		},
+		'options.startOfWeek': async function (val) {
+			await messenger.storage.local.set({
+				options: {
+					dark: this.options.dark,
+					addresses: this.options.addresses,
+					startOfWeek: val,
+					cache: this.options.cache,
+				}
+			})
+		},
+		'options.cache': async function (val) {
+			await messenger.storage.local.set({
+				options: {
+					dark: this.options.dark,
+					addresses: this.options.addresses,
+					startOfWeek: this.options.startOfWeek,
+					cache: val,
+				}
+			})
 		},
 	}
 }
@@ -118,12 +244,15 @@ html, body
 #options
 	width 100%
 	height 100%
-	min-height: 300px
+	// min-height: 300px
+
+	.container > h2
+		font-weight: 300
 
 	.entry
 		display: grid
 		grid-template-columns: 1fr 1fr
-		column-gap: 1rem
+		column-gap: 2rem
 		margin-bottom: 1rem
 
 		.action

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -136,7 +136,7 @@ export default {
 		// get all add-on settings
 		getSettings: async function () {
 			let result = await messenger.storage.local.get('options')
-		// only load options if they have been set, otherwise default settings will be kept
+			// only load options if they have been set, otherwise default settings will be kept
 			if (result && result.options) {
 				this.options.dark = result.options.dark ? true : false
 				this.options.addresses = result.options.addresses ? result.options.addresses : ''
@@ -271,7 +271,6 @@ html, body
 #options
 	width 100%
 	height 100%
-	// min-height: 300px
 
 	.container > h2
 		font-weight: 300

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -10,6 +10,7 @@
 		}'
 	>
 		<div class='container p-1'>
+			<!-- option: dark -->
 			<section class='entry'>
 				<label for='dark'>
 					{{ $t('options.darkMode.label') }}
@@ -23,6 +24,7 @@
 					</label>
 				</div>
 			</section>
+			<!-- option: addresses -->
 			<section class='entry'>
 				<label for='local'>
 					{{ $t('options.localIdentities.label') }}
@@ -32,6 +34,7 @@
 					<textarea v-model='addresses' placeholder='hello@devmount.de, another@example.com' id='local'></textarea>
 				</div>
 			</section>
+			<!-- option: startOfWeek -->
 			<section class='entry'>
 				<label for='start'>
 					{{ $t('options.startOfWeek.label') }}
@@ -43,6 +46,7 @@
 					</select>
 				</div>
 			</section>
+			<!-- save options -->
 			<section class='entry mt-5'>
 				<div></div>
 				<div class='action text-right'>
@@ -58,21 +62,25 @@ export default {
 	name: 'Options',
 	data () {
 		return {
-			addresses: '',
 			dark: true,
+			addresses: '',
 			startOfWeek: 0,
 		}
 	},
 	created () {
+		// initially load settings
 		this.getSettings()
 	},
 	methods: {
 		// get all add-on settings
 		getSettings: async function () {
 			let result = await messenger.storage.local.get('options')
-			this.addresses = result.options.addresses ? result.options.addresses : ''
-			this.dark = result.options.dark ? true : false
-			this.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
+		// only load options if they have been set, otherwise default settings will be kept
+			if (result && result.options) {
+				this.addresses = result.options.addresses ? result.options.addresses : ''
+				this.dark = result.options.dark ? true : false
+				this.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
+			}
 		},
 		// save current add-on settings
 		saveSettings: async function () {
@@ -86,6 +94,7 @@ export default {
 		}
 	},
 	computed: {
+		// array of localized, short day of week names
 		weekdayNames () {
 			let names = []
 			for (let wd = 1; wd <= 7; wd++) {

--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -1,10 +1,11 @@
 <template>
 	<div id='popup'>
 		<div class='container pt-1'>
+			<!-- header containing number of accounts and linking to stats page -->
 			<h3
-				@click.prevent="openTab(0)"
 				class="text-hover-accent2 cursor-pointer tooltip tooltip-bottom"
 				:data-tooltip='$t("popup.linkDescription")'
+				@click.prevent="openTab(0)"
 			>
 				<span class='mr-1'>{{ accounts.length }} {{ $tc('popup.account', accounts.length) }}</span>
 				<span v-if='waiting' class='dark loading'></span>
@@ -14,6 +15,7 @@
 					<polyline points="4 15 8 9 12 11 16 6 20 10 20 15 4 15" />
 				</svg>
 			</h3>
+			<!-- list of all accounts -->
 			<div class='accounts'>
 				<div
 					class="background-gray background-hover-accent2 text-hover-highlight cursor-pointer shadow"
@@ -38,12 +40,13 @@ export default {
 	name: 'Popup',
 	data () {
 		return {
-			accounts: [],
-			waiting: true,
-			dark: true
+			accounts: [],  // list of all existing accounts
+			waiting: true, // processessing folder and message counts indication
+			dark: true     // theme, always dark due to non colorable popup caret
 		}
 	},
 	created () {
+		// initially start account processing
 		this.getAccounts()
 	},
 	methods: {
@@ -65,16 +68,11 @@ export default {
 			})
 			this.accounts = accounts
 		},
-		// count all messages of a folder
+		// count all messages of given <folder>
 		countMessages: async function (folder) {
 			if (!folder) return 0
-			let page = null
 			let count = 0
-			try {
-				page = await messenger.messages.list(folder)
-			} catch (error) {
-				console.error(error)
-			}
+			let page  = await messenger.messages.list(folder)
 			if (page) {
 				count = page.messages.length
 			}
@@ -84,6 +82,7 @@ export default {
 			}
 			return count
 		},
+		// open the stats page as new tab with accounts appended as GET parameter
 		openTab (accountPosition) {
 			let url = 'stats.html'
 			if (accountPosition) url += '?a=' + accountPosition
@@ -91,11 +90,6 @@ export default {
 				active: true,
 				url: url
 			})
-		}
-	},
-	computed: {
-		scheme () {
-			return this.dark ? 'dark' : 'light'
 		}
 	}
 }

--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -75,10 +75,10 @@ export default {
 			let page  = await messenger.messages.list(folder)
 			if (page) {
 				count = page.messages.length
-			}
-			while (page.id) {
-				page = await messenger.messages.continueList(page.id)
-				count += page.messages.length
+				while (page.id) {
+					page = await messenger.messages.continueList(page.id)
+					count += page.messages.length
+				}
 			}
 			return count
 		},

--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -125,7 +125,7 @@ html, body
 			display: flex
 			flex-wrap: nowrap
 		.loading
-			loader 16px
+			loader 16px 3px
 		.accounts
 			display: flex
 			flex-direction: column

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -406,10 +406,10 @@ export default {
 				let page = await messenger.messages.list(folder)
 				if (page) {
 					page.messages.map(m => self.analyzeMessage(m, identities, hidden))
-				}
-				while (page.id) {
-					page = await messenger.messages.continueList(page.id)
-					page.messages.map(m => self.analyzeMessage(m, identities, hidden))
+					while (page.id) {
+						page = await messenger.messages.continueList(page.id)
+						page.messages.map(m => self.analyzeMessage(m, identities, hidden))
+					}
 				}
 			} else {
 				console.error('This folder doesn\'t exist')

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -385,12 +385,18 @@ export default {
 				await self.processMessages(f, identities)
 			})).then(() => {
 				// post processing: reduce size of contacts to configured limit
-				this.display.contacts.received = Object.keys(this.display.contacts.received)
+				let r = Object.entries(this.display.contacts.received)
+					.sort(([,a],[,b]) => b-a)
+					.reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
+				this.display.contacts.received = Object.keys(r)
 					.slice(0, this.preferences.sections.contacts.leaderCount)
-					.reduce((result, key) => { result[key] = this.display.contacts.received[key]; return result; }, {})
-				this.display.contacts.sent = Object.keys(this.display.contacts.sent)
+					.reduce((result, key) => { result[key] = r[key]; return result; }, {})
+				let s = Object.entries(this.display.contacts.sent)
+					.sort(([,a],[,b]) => b-a)
+					.reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
+				this.display.contacts.sent = Object.keys(s)
 					.slice(0, this.preferences.sections.contacts.leaderCount)
-					.reduce((result, key) => { result[key] = this.display.contacts.sent[key]; return result; }, {})
+					.reduce((result, key) => { result[key] = s[key]; return result; }, {})
 				// processing finished
 				this.waiting = false
 			})
@@ -657,16 +663,6 @@ export default {
 				return 0
 			}
 		},
-		leaderboardReceived () {
-			return Object.entries(this.display.contacts.received)
-				.sort(([,a],[,b]) => b-a)
-				.reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
-		},
-		leaderboardSent () {
-			return Object.entries(this.display.contacts.sent)
-				.sort(([,a],[,b]) => b-a)
-				.reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
-		},
 		yearsChartData () {
 			if (this.waiting) {
 				return {
@@ -908,7 +904,7 @@ export default {
 					labels: []
 				}
 			} else {
-				let r = this.leaderboardReceived
+				let r = this.display.contacts.received
 				return {
 					datasets: [
 						{ label: this.$t('stats.mailsReceived'), data: Object.values(r), color: 'rgb(10, 132, 255)', bcolor: 'rgb(10, 132, 255, .2)' },
@@ -924,7 +920,7 @@ export default {
 					labels: []
 				}
 			} else {
-				let s = this.leaderboardSent
+				let s = this.display.contacts.sent
 				return {
 					datasets: [
 						{ label: this.$t('stats.mailsSent'), data: Object.values(s), color: 'rgb(230, 77, 185)', bcolor: 'rgb(230, 77, 185, .2)' },

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -359,9 +359,11 @@ export default {
 		// get all add-on settings
 		getSettings: async function () {
 			let result = await messenger.storage.local.get('options')
-			this.preferences.localIdentities = result.options.addresses ? result.options.addresses.split(',').map(x => x.trim()) : []
-			this.preferences.dark = result.options.dark ? true : false
-			this.preferences.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
+			if (result && result.options) {
+				this.preferences.localIdentities = result.options.addresses ? result.options.addresses.split(',').map(x => x.trim()) : []
+				this.preferences.dark = result.options.dark ? true : false
+				this.preferences.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
+			}
 		},
 		getAccounts: async function () {
 			let accounts = await messenger.accounts.list()

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -988,104 +988,104 @@ export default {
 
 // general
 body
-	overflow-x hidden
+	overflow-x: hidden
 
 // layout and content
 #stats
-	min-height 100vh
+	min-height: 100vh
 
 	.container
-		width 100%
-		height 100%
-		margin 0 auto
-		padding-left 1rem
-		padding-right 1rem
-		box-sizing border-box
+		width: 100%
+		height: 100%
+		margin: 0 auto
+		padding-left: 1rem
+		padding-right: 1rem
+		box-sizing: border-box
 
 		@media (min-width: 2501px)
-			max-width 2500px
+			max-width: 2500px
 			#chart-area-main
-				grid-template-columns repeat(6, 1fr)
+				grid-template-columns: repeat(6, 1fr)
 		@media (max-width: 2500px)
-			max-width 2200px
+			max-width: 2200px
 			#chart-area-main
-				grid-template-columns repeat(3, 1fr)
+				grid-template-columns: repeat(3, 1fr)
 		@media (max-width: 2000px)
-			max-width 1750px
+			max-width: 1750px
 			#chart-area-main
-				grid-template-columns repeat(3, 1fr)
+				grid-template-columns: repeat(3, 1fr)
 		@media (max-width: 1500px)
-			max-width 1200px
+			max-width: 1200px
 			#chart-area-main
-				grid-template-columns repeat(2, 1fr)
+				grid-template-columns: repeat(2, 1fr)
 		@media (min-width: 961px)
 			.numbers
-				max-width 1500px
-				grid-template-columns repeat(6, 1fr)
+				max-width: 1500px
+				grid-template-columns: repeat(6, 1fr)
 			#chart-area-top
-				grid-template-columns calc(33.33% - 1rem) calc(66.66% - 1rem)
+				grid-template-columns: calc(33.33% - 1rem) calc(66.66% - 1rem)
 				&.first-column-only
-					grid-template-columns calc(100%-1rem) 0%
+					grid-template-columns: calc(100%-1rem) 0%
 				.resizer
 					display: list-item
 		@media (max-width: 960px)
 			.numbers
-				grid-template-columns repeat(3, 1fr)
+				grid-template-columns: repeat(3, 1fr)
 			#chart-area-top
-				grid-template-columns calc(100%-1rem)
+				grid-template-columns: calc(100%-1rem)
 				.resizer
 					display: none
 		@media (max-width: 720px)
 			#chart-area-main
-				grid-template-columns 1fr
+				grid-template-columns: 1fr
 
 		h1
-			margin-top 0
-			display grid
-			grid-template-columns auto 1fr auto 55px
-			align-items center
-			justify-content start
+			margin-top: 0
+			display: grid
+			grid-template-columns: auto 1fr auto 55px
+			align-items: center
+			justify-content: start
 			.logo
-				height 48px
+				height: 48px
 			.loading
 				loader 21px 3px
-				justify-self center
-				vertical-align text-top
+				justify-self: center
+				vertical-align: text-top
 			.refresh
-				justify-self center
+				justify-self: center
 				svg
-					vertical-align text-top
-					margin-top 1px
+					vertical-align: text-top
+					margin-top: 1px
 			select
-				justify-self end
+				justify-self: end
 
 		.numbers
-			display grid
-			column-gap 1rem
-			row-gap 2rem
-			margin 0 auto
+			display: grid
+			column-gap: 1rem
+			row-gap: 2rem
+			margin: 0 auto
 			&>div
-				text-align center
+				text-align: center
 				.featured
-					font-size 3.25em
-					line-height 1em
-					font-weight 500
+					font-size: 3.25em
+					line-height: 1em
+					font-weight: 500
 
 		.charts
 			.chart-area
-				display grid
-				column-gap 2rem
-				row-gap 1rem
-				transition grid-template-columns .2s
+				display: grid
+				column-gap: 2rem
+				row-gap: 1rem
+				transition: grid-template-columns .2s
 				& > *, .tab-content > *
-					min-height 380px
+					min-height: 380px
 				.chart
-					min-width 0
+					min-width: 0
 					h2
-						margin-bottom 0
+						margin-bottom: 0
 					p
-						margin-top 0
+						margin-top: 0
 				.chart-group .upper-chart h2
-					margin-top .5rem
+					margin-top: .5rem
 
 </style>

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -1,6 +1,7 @@
 <template>
 	<div id='stats' :class='scheme + " text-normal background-normal"'>
 		<div class='container pt-2 pb-6'>
+			{{ display }}
 			<h1>
 				<img class="logo mr-1" :src="`${publicPath}icon.svg`" alt="ThirdStats Logo">
 				<span class='mr-2'>Th<span class='text-gray'>underb</span>ird Stats</span>
@@ -337,6 +338,9 @@ export default {
 					},
 					days: {
 						year: (new Date()).getFullYear()
+					},
+					contacts: {
+						leaderCount: 20
 					}
 				},
 				dark: true,
@@ -378,8 +382,16 @@ export default {
 			let folders = traverseAccount(a)
 			let self = this
 			await Promise.all(folders.map(async f => {
+				// analyze all messages in all folders
 				await self.processMessages(f, identities)
 			})).then(() => {
+				// post processing: reduce size of contacts to configured limit
+				this.display.contacts.received = Object.keys(this.display.contacts.received)
+					.slice(0, this.preferences.sections.contacts.leaderCount)
+					.reduce((result, key) => { result[key] = this.display.contacts.received[key]; return result; }, {})
+				this.display.contacts.sent = Object.keys(this.display.contacts.sent)
+					.slice(0, this.preferences.sections.contacts.leaderCount)
+					.reduce((result, key) => { result[key] = this.display.contacts.sent[key]; return result; }, {})
 				this.waiting = false
 			})
 		},
@@ -891,13 +903,12 @@ export default {
 					labels: []
 				}
 			} else {
-				const leaderCount = 20
 				let r = this.leaderboardReceived
 				return {
 					datasets: [
-						{ label: this.$t('stats.mailsReceived'), data: Object.values(r).slice(0, leaderCount), color: 'rgb(10, 132, 255)', bcolor: 'rgb(10, 132, 255, .2)' },
+						{ label: this.$t('stats.mailsReceived'), data: Object.values(r), color: 'rgb(10, 132, 255)', bcolor: 'rgb(10, 132, 255, .2)' },
 					],
-					labels: Object.keys(r).slice(0, leaderCount)
+					labels: Object.keys(r)
 				}
 			}
 		},
@@ -908,13 +919,12 @@ export default {
 					labels: []
 				}
 			} else {
-				const leaderCount = 20
 				let s = this.leaderboardSent
 				return {
 					datasets: [
-						{ label: this.$t('stats.mailsSent'), data: Object.values(s).slice(0, leaderCount), color: 'rgb(230, 77, 185)', bcolor: 'rgb(230, 77, 185, .2)' },
+						{ label: this.$t('stats.mailsSent'), data: Object.values(s), color: 'rgb(230, 77, 185)', bcolor: 'rgb(230, 77, 185, .2)' },
 					],
-					labels: Object.keys(s).slice(0, leaderCount)
+					labels: Object.keys(s)
 				}
 			}
 		},

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -383,19 +383,19 @@ export default {
 				// analyze all messages in all folders
 				await self.processMessages(f, identities, hidden)
 			})).then(() => {
-				let store = hidden ? this.store : this.display
+				let store = hidden ? self.store : self.display
 				// post processing: reduce size of contacts to configured limit
 				let r = Object.entries(store.contacts.received).sort(([,a],[,b]) => b-a).reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
 				store.contacts.received = Object.keys(r)
-					.slice(0, this.preferences.sections.contacts.leaderCount)
+					.slice(0, self.preferences.sections.contacts.leaderCount)
 					.reduce((result, key) => { result[key] = r[key]; return result; }, {})
 				let s = Object.entries(store.contacts.sent).sort(([,a],[,b]) => b-a).reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
 				store.contacts.sent = Object.keys(s)
-					.slice(0, this.preferences.sections.contacts.leaderCount)
+					.slice(0, self.preferences.sections.contacts.leaderCount)
 					.reduce((result, key) => { result[key] = s[key]; return result; }, {})
 				// post processing: display data now if it was processed in background
 				if (hidden) {
-					this.display = JSON.parse(JSON.stringify(this.store))
+					self.display = JSON.parse(JSON.stringify(self.store))
 				}
 			})
 		},
@@ -411,8 +411,6 @@ export default {
 						page.messages.map(m => self.analyzeMessage(m, identities, hidden))
 					}
 				}
-			} else {
-				console.error('This folder doesn\'t exist')
 			}
 		},
 		// extract information of a single message
@@ -582,10 +580,14 @@ export default {
 				this.loading = true
 			} else {
 				this.waiting = true
-			} 
+			}
+			// reset already processed data
 			this.reset(hidden)
+			// get currently selected account
 			let account = await messenger.accounts.get(this.activeAccount)
+			// process data of this account again and update this.display
 			await this.processAccount(account, hidden)
+			// store reprocessed data
 			let stats = {}
 			stats['stats-' + this.activeAccount] = JSON.parse(JSON.stringify(this.display))
 			await messenger.storage.local.set(stats)
@@ -594,7 +596,7 @@ export default {
 				this.loading = false
 			} else {
 				this.waiting = false
-			} 
+			}
 		},
 		// activate tab of given <key>
 		activateTab (key) {

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -8,16 +8,21 @@
 				<select v-model='activeAccount' name='account' :disabled='waiting || loading' class="shadow" :class='{ disabled: waiting || loading }'>
 					<option v-for='a in accounts' :key='a.id' :value='a.id'>{{ a.name }}</option>
 				</select>
-				<div v-show='waiting || loading' :class='scheme + " loading"'></div>
-				<div v-show='!waiting && !loading' class='refresh cursor-pointer' @click='refresh(true)'>
-					<svg class='icon icon-bold icon-gray' viewBox='0 0 24 24'>
+				<div v-show='waiting || loading' :class='scheme + " loading loader-accent2"'></div>
+				<div
+					v-show='!waiting && !loading'
+					class='refresh cursor-pointer tooltip tooltip-bottom'
+					:data-tooltip='$t("stats.tooltips.refresh")'
+					@click='refresh(true)'
+				>
+					<svg class='icon icon-bold icon-gray icon-hover-accent2' viewBox='0 0 24 24'>
 						<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-						<path d="M9 4.55a8 8 0 0 1 6 14.9m0 -4.45v5h5" />
-						<line x1="5.63" y1="7.16" x2="5.63" y2="7.17" />
-						<line x1="4.06" y1="11" x2="4.06" y2="11.01" />
-						<line x1="4.63" y1="15.1" x2="4.63" y2="15.11" />
-						<line x1="7.16" y1="18.37" x2="7.16" y2="18.38" />
-						<line x1="11" y1="19.94" x2="11" y2="19.95" />
+						<path class="icon-part-accent2" d="M9 4.55a8 8 0 0 1 6 14.9m0 -4.45v5h5" />
+						<line class="icon-part-accent2-dark" x1="5.63" y1="7.16" x2="5.63" y2="7.17" />
+						<line class="icon-part-accent2-dark" x1="4.06" y1="11" x2="4.06" y2="11.01" />
+						<line class="icon-part-accent2-dark" x1="4.63" y1="15.1" x2="4.63" y2="15.11" />
+						<line class="icon-part-accent2-dark" x1="7.16" y1="18.37" x2="7.16" y2="18.38" />
+						<line class="icon-part-accent2-dark" x1="11" y1="19.94" x2="11" y2="19.95" />
 					</svg>
 				</div>
 			</h1>

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -18,26 +18,26 @@
 				<!-- total -->
 				<div>
 					<div class='text-gray'>{{ $t('stats.mailsTotal') }}</div>
-					<div class='featured'>{{ numbers.total.toLocaleString() }}</div>
+					<div class='featured'>{{ display.numbers.total.toLocaleString() }}</div>
 					<div class='text-gray'>{{ $t('stats.withinYears', [oneDigit(years)]) }}</div>
 				</div>
 				<!-- unread -->
 				<div>
 					<div class='text-gray'>{{ $t('stats.mailsUnread') }}</div>
-					<div class='featured'>{{ numbers.unread.toLocaleString() }}</div>
-					<div class='text-gray' v-if='numbers.unread == 0'>{{ $t('stats.niceWork') }}</div>
+					<div class='featured'>{{ display.numbers.unread.toLocaleString() }}</div>
+					<div class='text-gray' v-if='display.numbers.unread == 0'>{{ $t('stats.niceWork') }}</div>
 					<div class='text-gray' v-else>{{ $t('stats.percentOfReceived', [unreadPercentage]) }}</div>
 				</div>
 				<!-- received -->
 				<div>
 					<div class='text-accent2'>{{ $t('stats.mailsReceived') }}</div>
-					<div class='featured text-accent2'>{{ numbers.received.toLocaleString() }}</div>
+					<div class='featured text-accent2'>{{ display.numbers.received.toLocaleString() }}</div>
 					<div class='text-gray'>{{ $t('stats.percentOfTotal', [receivedPercentage]) }}</div>
 				</div>
 				<!-- sent -->
 				<div>
 					<div class='text-accent1'>{{ $t('stats.mailsSent') }}</div>
-					<div class='featured text-accent1'>{{ numbers.sent.toLocaleString() }}</div>
+					<div class='featured text-accent1'>{{ display.numbers.sent.toLocaleString() }}</div>
 					<div class='text-gray'>{{ $t('stats.percentOfTotal', [sentPercentage]) }}</div>
 				</div>
 				<!-- per month / per year -->
@@ -65,7 +65,7 @@
 				</div>
 			</section>
 			<!-- empty account -->
-			<section v-else-if='numbers.total == 0' class='mt-5'>
+			<section v-else-if='display.numbers.total == 0' class='mt-5'>
 				<svg class="icon icon-huge icon-gray d-block m-0-auto" viewBox="0 0 24 24">
 					<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
 					<rect x="4" y="4" width="16" height="16" rx="2" />
@@ -311,17 +311,19 @@ export default {
 			accounts: [],
 			activeAccount: null,
 			waiting: true,
-			numbers: {},
-			yearsData: {},
-			quartersData: {},
-			monthsData: {},
-			weeksData: {},
-			daysData: {},
-			daytimeData: {},
-			weekdayData: {},
-			monthData: {},
-			weekdayPerHourData: {},
-			contacts: {},
+			display: {
+				numbers: {},
+				yearsData: {},
+				quartersData: {},
+				monthsData: {},
+				weeksData: {},
+				daysData: {},
+				daytimeData: {},
+				weekdayData: {},
+				monthData: {},
+				weekdayPerHourData: {},
+				contacts: {},
+			},
 			tabs: {
 				years: true,
 				quarters: false,
@@ -406,96 +408,96 @@ export default {
 		analyzeMessage (m, identities) {
 			let type = ''
 			// numbers
-			this.numbers.total++
-			if (m.read === false) this.numbers.unread++
+			this.display.numbers.total++
+			if (m.read === false) this.display.numbers.unread++
 			let author = extractEmailAddress(m.author)
 			if (identities.includes(author)) {
-				this.numbers.sent++
+				this.display.numbers.sent++
 				type = 'sent'
 			} else {
-				this.numbers.received++
+				this.display.numbers.received++
 				type = 'received'
 			}
 			// calculate starting date (= date of oldest email)
-			if (m.date && m.date.getTime() > 0 && m.date.getTime() < this.numbers.start.getTime()) {
-				this.numbers.start = m.date
+			if (m.date && m.date.getTime() > 0 && m.date.getTime() < this.display.numbers.start.getTime()) {
+				this.display.numbers.start = m.date
 			}
 			// years
 			let y = m.date.getFullYear()
-			if (!(y in this.yearsData[type])) {
-				this.yearsData[type][y] = 1
+			if (!(y in this.display.yearsData[type])) {
+				this.display.yearsData[type][y] = 1
 			} else {
-				this.yearsData[type][y]++
+				this.display.yearsData[type][y]++
 			}
 			// quarters
 			let qn = quarterNumber(m.date)
-			if (!(y in this.quartersData[type])) {
-				this.quartersData[type][y] = {}
-				this.quartersData[type][y][qn] = 1
+			if (!(y in this.display.quartersData[type])) {
+				this.display.quartersData[type][y] = {}
+				this.display.quartersData[type][y][qn] = 1
 			} else {
-				if (!(qn in this.quartersData[type][y])) {
-					this.quartersData[type][y][qn] = 1
+				if (!(qn in this.display.quartersData[type][y])) {
+					this.display.quartersData[type][y][qn] = 1
 				} else {
-					this.quartersData[type][y][qn]++
+					this.display.quartersData[type][y][qn]++
 				}
 			}
 			// months
 			let mo = m.date.getMonth()
-			if (!(y in this.monthsData[type])) {
-				this.monthsData[type][y] = {}
-				this.monthsData[type][y][mo] = 1
+			if (!(y in this.display.monthsData[type])) {
+				this.display.monthsData[type][y] = {}
+				this.display.monthsData[type][y][mo] = 1
 			} else {
-				if (!(mo in this.monthsData[type][y])) {
-					this.monthsData[type][y][mo] = 1
+				if (!(mo in this.display.monthsData[type][y])) {
+					this.display.monthsData[type][y][mo] = 1
 				} else {
-					this.monthsData[type][y][mo]++
+					this.display.monthsData[type][y][mo]++
 				}
 			}
 			// weeks
 			let wn = weekNumber(m.date)
-			if (!(y in this.weeksData[type])) {
-				this.weeksData[type][y] = {}
-				this.weeksData[type][y][wn] = 1
+			if (!(y in this.display.weeksData[type])) {
+				this.display.weeksData[type][y] = {}
+				this.display.weeksData[type][y][wn] = 1
 			} else {
-				if (!(wn in this.weeksData[type][y])) {
-					this.weeksData[type][y][wn] = 1
+				if (!(wn in this.display.weeksData[type][y])) {
+					this.display.weeksData[type][y][wn] = 1
 				} else {
-					this.weeksData[type][y][wn]++
+					this.display.weeksData[type][y][wn]++
 				}
 			}
 			// daytime
 			let dt = m.date.getHours()
-			this.daytimeData[type][dt]++
+			this.display.daytimeData[type][dt]++
 			// weekday
 			let wd = m.date.getDay()
-			this.weekdayData[type][wd]++
+			this.display.weekdayData[type][wd]++
 			// month
-			this.monthData[type][mo]++
+			this.display.monthData[type][mo]++
 			// weekday per calendar week
-			if (!(y in this.daysData[type])) {
-				this.daysData[type][y] = new NumberedObject(7,53)
+			if (!(y in this.display.daysData[type])) {
+				this.display.daysData[type][y] = new NumberedObject(7,53)
 			}
-			this.daysData[type][y][wd][wn-1]++
+			this.display.daysData[type][y][wd][wn-1]++
 			// weekday per hour
-			this.weekdayPerHourData[type][wd][dt]++
+			this.display.weekdayPerHourData[type][wd][dt]++
 			// contacts
 			switch (type) {
 				case 'sent':
 					let recipients = m.recipients.map(r => extractEmailAddress(r).toLowerCase())
 					recipients.map(r => {
-						if (!(r in this.contacts['sent'])) {
-							this.contacts['sent'][r] = 1
+						if (!(r in this.display.contacts['sent'])) {
+							this.display.contacts['sent'][r] = 1
 						} else {
-							this.contacts['sent'][r]++
+							this.display.contacts['sent'][r]++
 						}
 					})
 					break;
 				case 'received':
 					let a = author.toLowerCase()
-					if (!(a in this.contacts['received'])) {
-						this.contacts['received'][a] = 1
+					if (!(a in this.display.contacts['received'])) {
+						this.display.contacts['received'][a] = 1
 					} else {
-						this.contacts['received'][a]++
+						this.display.contacts['received'][a]++
 					}
 					break;
 				default:
@@ -503,50 +505,50 @@ export default {
 			}
 		},
 		reset () {
-			this.numbers = {
+			this.display.numbers = {
 				total: 0,
 				unread: 0,
 				received: 0,
 				sent: 0,
 				start: new Date(),
 			}
-			this.yearsData = {
+			this.display.yearsData = {
 				received: {},
 				sent: {},
 			}
-			this.quartersData = {
+			this.display.quartersData = {
 				received: {},
 				sent: {},
 			}
-			this.monthsData = {
+			this.display.monthsData = {
 				received: {},
 				sent: {},
 			}
-			this.weeksData = {
+			this.display.weeksData = {
 				received: {},
 				sent: {},
 			}
-			this.daysData = {
+			this.display.daysData = {
 				received: {},
 				sent: {},
 			}
-			this.daytimeData = {
+			this.display.daytimeData = {
 				received: new NumberedObject(24),
 				sent: new NumberedObject(24),
 			}
-			this.weekdayData = {
+			this.display.weekdayData = {
 				received: new NumberedObject(7),
 				sent: new NumberedObject(7),
 			}
-			this.monthData = {
+			this.display.monthData = {
 				received: new NumberedObject(12),
 				sent: new NumberedObject(12),
 			}
-			this.weekdayPerHourData = {
+			this.display.weekdayPerHourData = {
 				received: new NumberedObject(7,24),
 				sent: new NumberedObject(7,24),
 			}
-			this.contacts = {
+			this.display.contacts = {
 				received: {},
 				sent: {},
 			}
@@ -582,7 +584,7 @@ export default {
 		days () {
 			const oneDay = 24 * 60 * 60 * 1000
 			let today = new Date()
-			return Math.round(Math.abs((this.numbers.start - today) / oneDay))
+			return Math.round(Math.abs((this.display.numbers.start - today) / oneDay))
 		},
 		weeks () {
 			return this.days/7
@@ -594,61 +596,61 @@ export default {
 			return this.days/365
 		},
 		receivedPercentage () {
-			if (this.numbers.total > 0) {
-				return this.twoDigit(this.numbers.received*100/this.numbers.total)
+			if (this.display.numbers.total > 0) {
+				return this.twoDigit(this.display.numbers.received*100/this.display.numbers.total)
 			} else {
 				return 0
 			}
 		},
 		sentPercentage () {
-			if (this.numbers.total > 0) {
-				return this.twoDigit(this.numbers.sent*100/this.numbers.total)
+			if (this.display.numbers.total > 0) {
+				return this.twoDigit(this.display.numbers.sent*100/this.display.numbers.total)
 			} else {
 				return 0
 			}
 		},
 		unreadPercentage () {
-			if (this.numbers.received > 0) {
-				return this.twoDigit(this.numbers.unread*100/this.numbers.received)
+			if (this.display.numbers.received > 0) {
+				return this.twoDigit(this.display.numbers.unread*100/this.display.numbers.received)
 			} else {
 				return 0
 			}
 		},
 		perDay () {
-			if (this.numbers.total > 0 && this.days > 0) {
-				return this.oneDigit(this.numbers.total/this.days)
+			if (this.display.numbers.total > 0 && this.days > 0) {
+				return this.oneDigit(this.display.numbers.total/this.days)
 			} else {
 				return 0
 			}
 		},
 		perWeek () {
-			if (this.numbers.total > 0 && this.weeks > 0) {
-				return this.oneDigit(this.numbers.total/this.weeks)
+			if (this.display.numbers.total > 0 && this.weeks > 0) {
+				return this.oneDigit(this.display.numbers.total/this.weeks)
 			} else {
 				return 0
 			}
 		},
 		perMonth () {
-			if (this.numbers.total > 0 && this.months > 0) {
-				return this.oneDigit(this.numbers.total/this.months)
+			if (this.display.numbers.total > 0 && this.months > 0) {
+				return this.oneDigit(this.display.numbers.total/this.months)
 			} else {
 				return 0
 			}
 		},
 		perYear () {
-			if (this.numbers.total > 0 && this.years > 0) {
-				return this.oneDigit(this.numbers.total/this.years)
+			if (this.display.numbers.total > 0 && this.years > 0) {
+				return this.oneDigit(this.display.numbers.total/this.years)
 			} else {
 				return 0
 			}
 		},
 		leaderboardReceived () {
-			return Object.entries(this.contacts.received)
+			return Object.entries(this.display.contacts.received)
 				.sort(([,a],[,b]) => b-a)
 				.reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
 		},
 		leaderboardSent () {
-			return Object.entries(this.contacts.sent)
+			return Object.entries(this.display.contacts.sent)
 				.sort(([,a],[,b]) => b-a)
 				.reduce((r, [k, v]) => ({ ...r, [k]: v }), {})
 		},
@@ -659,9 +661,9 @@ export default {
 					labels: []
 				}
 			} else {
-				let r = this.yearsData.received, s = this.yearsData.sent
+				let r = this.display.yearsData.received, s = this.display.yearsData.sent
 				let today = new Date()
-				for (let y = this.numbers.start.getFullYear(); y <= today.getFullYear(); ++y) {
+				for (let y = this.display.numbers.start.getFullYear(); y <= today.getFullYear(); ++y) {
 					if (!r[y]) r[y] = 0
 					if (!s[y]) s[y] = 0
 				}
@@ -681,14 +683,14 @@ export default {
 					labels: []
 				}
 			} else {
-				let r = this.quartersData.received
-				let s = this.quartersData.sent
+				let r = this.display.quartersData.received
+				let s = this.display.quartersData.sent
 				let labels = [], dr = [], ds = []
 				let today = new Date()
-				for (let y = this.numbers.start.getFullYear(); y <= today.getFullYear(); ++y) {
+				for (let y = this.display.numbers.start.getFullYear(); y <= today.getFullYear(); ++y) {
 					for (let q = 1; q <= 4; ++q) {
 						// trim quarters before start date
-						if (y == this.numbers.start.getFullYear() && q < quarterNumber(this.numbers.start)) continue
+						if (y == this.display.numbers.start.getFullYear() && q < quarterNumber(this.display.numbers.start)) continue
 						// trim quarters in future
 						if (y == today.getFullYear() && q > quarterNumber(today)) break
 						// organize labels and data
@@ -713,14 +715,14 @@ export default {
 					labels: []
 				}
 			} else {
-				let r = this.monthsData.received
-				let s = this.monthsData.sent
+				let r = this.display.monthsData.received
+				let s = this.display.monthsData.sent
 				let labels = [], dr = [], ds = []
 				let today = new Date()
-				for (let y = this.numbers.start.getFullYear(); y <= today.getFullYear(); ++y) {
+				for (let y = this.display.numbers.start.getFullYear(); y <= today.getFullYear(); ++y) {
 					for (let m = 0; m < 12; ++m) {
 						// trim months before start date
-						if (y == this.numbers.start.getFullYear() && m < this.numbers.start.getMonth()) continue
+						if (y == this.display.numbers.start.getFullYear() && m < this.display.numbers.start.getMonth()) continue
 						// trim months in future
 						if (y == today.getFullYear() && m > today.getMonth()) break
 						// organize labels and data
@@ -745,14 +747,14 @@ export default {
 					labels: []
 				}
 			} else {
-				let r = this.weeksData.received
-				let s = this.weeksData.sent
+				let r = this.display.weeksData.received
+				let s = this.display.weeksData.sent
 				let labels = [], dr = [], ds = []
 				let today = new Date()
-				for (let y = this.numbers.start.getFullYear(); y <= today.getFullYear(); ++y) {
+				for (let y = this.display.numbers.start.getFullYear(); y <= today.getFullYear(); ++y) {
 					for (let w = 1; w <= weeksInYear(y); ++w) {
 						// trim weeks before start date
-						if (y == this.numbers.start.getFullYear() && w < weekNumber(this.numbers.start)) continue
+						if (y == this.display.numbers.start.getFullYear() && w < weekNumber(this.display.numbers.start)) continue
 						// trim weeks in future
 						if (y == today.getFullYear() && w > weekNumber(today)) break
 						// organize labels and data
@@ -777,7 +779,7 @@ export default {
 					labels: []
 				}
 			} else {
-				let r = this.daytimeData.received, s = this.daytimeData.sent
+				let r = this.display.daytimeData.received, s = this.display.daytimeData.sent
 				return {
 					datasets: [
 						{ label: this.$t('stats.mailsSent'), data: Object.values(s), color: 'rgb(230, 77, 185)', bcolor: 'rgb(230, 77, 185, .2)' },
@@ -794,8 +796,8 @@ export default {
 					labels: []
 				}
 			} else {
-				let r = Object.values(this.weekdayData.received)
-				let s = Object.values(this.weekdayData.sent)
+				let r = Object.values(this.display.weekdayData.received)
+				let s = Object.values(this.display.weekdayData.sent)
 				let labels = [...this.weekdayNames]
 				// start week with user defined day of week
 				for (let d = 0; d < this.preferences.startOfWeek; d++) {
@@ -819,7 +821,7 @@ export default {
 					labels: []
 				}
 			} else {
-				let r = this.monthData.received, s = this.monthData.sent
+				let r = this.display.monthData.received, s = this.display.monthData.sent
 				return {
 					datasets: [
 						{ label: this.$t('stats.mailsSent'), data: Object.values(s), color: 'rgb(230, 77, 185)', bcolor: 'rgb(230, 77, 185, .2)' },
@@ -836,11 +838,11 @@ export default {
 					sent: new NumberedObject(7,53),
 				}
 			} else {
-				let r = this.preferences.sections.days.year in this.daysData.received
-					? Object.values(this.daysData.received[this.preferences.sections.days.year])
+				let r = this.preferences.sections.days.year in this.display.daysData.received
+					? Object.values(this.display.daysData.received[this.preferences.sections.days.year])
 					: Object.values(new NumberedObject(7,53))
-				let s = this.preferences.sections.days.year in this.daysData.sent
-					? Object.values(this.daysData.sent[this.preferences.sections.days.year])
+				let s = this.preferences.sections.days.year in this.display.daysData.sent
+					? Object.values(this.display.daysData.sent[this.preferences.sections.days.year])
 					: Object.values(new NumberedObject(7,53))
 				let ylabels = [...this.weekdayNames]
 				let xlabels = Array.from(Array(54).keys())
@@ -866,8 +868,8 @@ export default {
 					sent: new NumberedObject(7,24),
 				}
 			} else {
-				let r = Object.values(this.weekdayPerHourData.received)
-				let s = Object.values(this.weekdayPerHourData.sent)
+				let r = Object.values(this.display.weekdayPerHourData.received)
+				let s = Object.values(this.display.weekdayPerHourData.sent)
 				let labels = [...this.weekdayNames]
 				// start week with user defined day of week
 				for (let d = 0; d < this.preferences.startOfWeek; d++) {

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -156,6 +156,8 @@ for m, c in mode
 	display: block
 .d-inline
 	display: inline
+.d-inline-block
+	display: inline-block
 .position-absolute
 	position: absolute
 .position-relative
@@ -194,6 +196,9 @@ for m, c in mode
 	&.icon-thin
 		stroke-width: 1
 	
+	&.icon-bold
+		stroke-width: 2
+
 	&.icon-strong
 		stroke-width: 3
 
@@ -381,7 +386,7 @@ textarea
 				color: c.accent2
 
 // loader
-loader(size)
+loader(size, border)
 	display: inline-block
 	height: size
 	width: size
@@ -389,7 +394,7 @@ loader(size)
 	animation: rotate 1s 0s infinite linear
 	for m, c in mode
 		&.{m}
-			border: 4px solid c.gray3
+			border: border solid c.gray3
 			border-top-color: c.gray1
 
 // tooltip

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -180,6 +180,7 @@ for m, c in mode
 	stroke-linejoin: round
 	width: 2rem
 	height: 2rem
+	transition: all 0.2s ease
 
 	&.icon-text
 		width: 1rem
@@ -206,10 +207,19 @@ for m, c in mode
 		.{m} &
 			&.icon-{m}
 				color: c.icon
-
 			&.icon-gray
 				stroke: c.gray2
-
+			&.icon-hover-accent > *
+				transition: inherit
+			&.icon-hover-accent:hover
+				.icon-part-accent1
+					stroke: c.accent1
+				.icon-part-accent1-dark
+					stroke: darken(c.accent1, 60%)
+				.icon-part-accent2
+					stroke: c.accent2
+				.icon-part-accent2-dark
+					stroke: darken(c.accent2, 60%)
 			&.icon-animated-color-transition
 				animation: unquote(m+ColorFading) 1s 0s infinite ease alternate
 
@@ -392,10 +402,14 @@ loader(size, border)
 	width: size
 	border-radius: 50%
 	animation: rotate 1s 0s infinite linear
+	border: border solid
 	for m, c in mode
 		&.{m}
-			border: border solid c.gray3
+			border-color: c.gray3
 			border-top-color: c.gray1
+			&.loader-accent2
+				border-color: darken(c.accent2, 60%)
+				border-top-color: c.accent2
 
 // tooltip
 .tooltip
@@ -406,10 +420,11 @@ loader(size, border)
 		bottom: 100%
 		content: attr(data-tooltip)
 		display: block
-		font-size: .75em
+		font-size: .7rem
+		font-weight: normal
 		left: 50%
 		opacity: 0
-		padding: .5em
+		padding: .5rem
 		pointer-events: none
 		position: absolute
 		transform: translate(-50%, .8rem)

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -48,6 +48,12 @@ a, a:visited
 			color: c.accent2
 			&:hover
 				color: c.accent1
+hr
+	border: none
+	height: 1px
+	for m, c in mode
+		.{m} &
+			background: c.gray2
 
 // animations
 @keyframes rotate
@@ -113,12 +119,16 @@ for m, c in mode
 	font-size: .85em
 .text-tiny
 	font-size: .75em
+.text-thin
+	font-weight: 300
 .mr-1
 	margin-right: 1rem
 .mt-1
 	margin-top: 1rem
 .mt-2
 	margin-top: 2rem
+.mt-3
+	margin-top: 3rem
 .mt-5
 	margin-top: 5rem
 .mr-1
@@ -133,6 +143,9 @@ for m, c in mode
 	margin-bottom: 1rem
 .mt-6
 	margin-top: 6rem
+.my-3
+	margin-top: 3rem
+	margin-bottom: 3rem
 .my-6
 	margin-top: 6rem
 	margin-bottom: 6rem
@@ -158,6 +171,10 @@ for m, c in mode
 	display: inline
 .d-inline-block
 	display: inline-block
+.d-flex
+	display: flex
+.flex-grow
+	flex-grow: 1
 .position-absolute
 	position: absolute
 .position-relative
@@ -237,6 +254,8 @@ button
 	padding: 1rem 2rem
 	transition: background .2s
 	color: mode.dark.highlight
+	&.button-inline
+		padding: .5rem
 	for m, c in mode
 		.{m} &
 			background: c.accent2
@@ -267,13 +286,13 @@ select
 			border-color: c.accent2
 			box-shadow: 0 0 0 .25rem rgba(c.accent2, .2)
 
+input[type=text],
+input[type=email],
 textarea
 	appearance: none
 	border: solid 1px
 	border-radius: 2px
-	width: 100%
 	padding: .5rem
-	font-size: .9rem
 	for m, c in mode
 		.{m} &
 			background: c.back
@@ -285,6 +304,9 @@ textarea
 		.{m} &:focus
 			border-color: c.accent2
 			box-shadow: 0 0 0 .25rem rgba(c.accent2, .2)
+textarea
+	width: 100%
+	font-size: .9rem
 
 .switch
 	padding: 0
@@ -394,6 +416,21 @@ textarea
 			.tab-item.active > span
 				border-bottom-color: c.accent2
 				color: c.accent2
+
+// tags
+.tag
+	display: inline-block
+	margin: .5rem .5rem 0 0
+	padding: .2rem .2rem .2rem .5rem
+	&>*
+		vertical-align: middle
+	for m, c in mode
+		.{m} &
+			color: c.front
+			if m is 'dark'
+				background: c.gray3
+			else
+				background: c.back
 
 // loader
 loader(size, border)

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -253,6 +253,7 @@ button
 	border-radius: 2px
 	padding: 1rem 2rem
 	transition: background .2s
+	cursor: pointer
 	color: mode.dark.highlight
 	&.button-inline
 		padding: .5rem

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,10 +43,21 @@ let quarterNumber = (d) => {
 	return (Math.ceil(month / 3))
 }
 
+// function to format bytes and append unit
+let formatBytes = (bytes, decimals=2) => {
+	if (bytes === 0) return '0 Bytes'
+	const k = 1024
+	const dm = decimals < 0 ? 0 : decimals
+	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+	const i = Math.floor(Math.log(bytes) / Math.log(k))
+	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
+}
+
 export {
 	traverseAccount,
 	extractEmailAddress,
 	weekNumber,
 	weeksInYear,
-	quarterNumber
+	quarterNumber,
+	formatBytes
 }


### PR DESCRIPTION
## Description of the Change

This implements a caching system to only process accounts once. Accounts can be manually reprocessed. Caching system can be activated/deactivate in add-on options. Cache can be cleared in add-on options.

## Benefits

After initial loading, switching accounts is a lot faster.
Manual refresh button:
![image](https://user-images.githubusercontent.com/5441654/100542003-de628f00-3247-11eb-8a5b-8cb3f9f44d1a.png)

Options are now organized in sections. Caching is added:
![image](https://user-images.githubusercontent.com/5441654/100542040-18cc2c00-3248-11eb-9997-332fe9a1dc77.png)


## Applicable Issues

Closes #130 and #131
