### PR TITLE
🔨 fix polish pluralisation rules

### DIFF
--- a/src/stats.js
+++ b/src/stats.js
@@ -41,6 +41,20 @@ const i18n = new VueI18n({
 	locale: messenger.i18n.getUILanguage(),
 	fallbackLocale: 'en',
 	messages,
+	pluralizationRules: {
+		'pl': (choice) => {
+			if (choice === 1) {
+				return 1;
+			}
+
+			const endsWith = choice % 10;
+			if (([2, 3, 4].indexOf(endsWith) >= 0) && (choice < 12) && (choice > 14)) {
+				return 2;
+			}
+
+			return 0;
+		}
+	}
 })
 
 new Vue({


### PR DESCRIPTION
Closes #41 

## Description of the Change

Adds the polish plualization form. Messages should be now (according to the issue description): `{0} komentarzy | {0} komentarz | {0} komentarze`

## Benefits

Translators should now be able to translate Third Stats to polish in full.

## Applicable Issues

See #41 
