### PR TITLE
Time period stats

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -24,6 +24,7 @@
     "mailsWeek": "mails/week",
     "loadingInProgress": "Loading of all emails from this account in progress...",
     "accountEmpty": "This account is empty, no emails here.",
+    "timePeriod": "Time Period",
     "charts": {
       "years": {
         "title": "Years",
@@ -82,7 +83,17 @@
       "expand": "Expand chart area",
       "shrink": "Shrink chart area",
       "refresh": "Refresh data",
-      "clear": "Clear selection"
+      "clear": "Clear selection",
+      "period": {
+        "start": "From Date\nTip: Typing '201125' becomes '2020-11-25'",
+        "end": "To Date\nTip: Typing '201125' becomes '2020-11-25'"
+      },
+      "error": {
+        "empty": "Input is required",
+        "dateFormat": "Format YYYY-MM-DD is required, e.g. 2020-01-31",
+        "dateOrderStart": "Start date must be before end date",
+        "dateOrderEnd": "End date must be after start date"
+      }
     },
     "abbreviations": {
       "calendarWeek": "W",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -91,6 +91,7 @@
       "error": {
         "empty": "Input is required",
         "dateFormat": "Format YYYY-MM-DD is required, e.g. 2020-01-31",
+        "dateUnreal": "A valid date is required",
         "dateOrderStart": "Start date must be before end date",
         "dateOrderEnd": "End date must be after start date"
       }

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -12,7 +12,7 @@
 					<!-- account selection -->
 					<div class='filter-account d-flex'>
 						<label for='account' class='align-center text-gray p-0-5'>{{ $tc('popup.account', 1) }}</label>
-						<select v-model='active.account' :disabled='waiting || loading' class='align-stretch shadow w-6' :class='{ disabled: waiting || loading }' id='account'>
+						<select v-model='active.account' :disabled='waiting || loading' class='align-stretch w-6' :class='{ disabled: waiting || loading }' id='account'>
 							<option v-for='a in accounts' :key='a.id' :value='a.id'>{{ a.name }}</option>
 						</select>
 						<div v-show='waiting || loading' :class='scheme + " loading align-center loader-accent2"'></div>
@@ -36,7 +36,7 @@
 					<!-- folder selection -->
 					<div class='filter-folder d-flex ml-2'>
 						<label for='folder' class='align-center text-gray p-0-5'>{{ $tc('popup.folder', 1) }}</label>
-						<select v-model='active.folder' :disabled='waiting || loading' class='align-stretch shadow w-6' :class='{ disabled: waiting || loading }' id='folder'>
+						<select v-model='active.folder' :disabled='waiting || loading' class='align-stretch w-6' :class='{ disabled: waiting || loading }' id='folder'>
 							<option v-for='f in folders' :key='f.path' :value='f'>{{ formatFolder(f) }}</option>
 						</select>
 						<div class='cursor-pointer tooltip tooltip-bottom d-inline-flex align-center' :data-tooltip='$t("stats.tooltips.clear")' @click='resetFolder'>
@@ -204,7 +204,7 @@
 						</div>
 					</div>
 					<div v-show='!preferences.sections.total.expand' class="chart-group position-relative">
-						<select v-model='preferences.sections.days.year' name='year' class="position-absolute top-0-5 right-0-5 shadow">
+						<select v-model='preferences.sections.days.year' name='year' class="position-absolute top-0-5 right-0-5">
 							<option v-for='y in yearsList' :key='y' :value='y'>{{ y }}</option>
 						</select>
 						<!-- emails per weekday per hour received -->

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -796,6 +796,7 @@ export default {
 		// returns true if entered time period is valid
 		validPeriod () {
 			let valid = true
+			const datex = RegExp(/^\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])$/)
 			this.error.period.start = []
 			this.error.period.end = []
 			// start time is not set
@@ -803,20 +804,30 @@ export default {
 				valid = false
 				this.error.period.start.push(this.$t('stats.tooltips.error.empty'))
 			}
-			// start time is no valid date
-			if (isNaN(Date.parse(this.active.period.start))) {
+			// start time is of wrong format
+			if (!datex.test(this.active.period.start)) {
 				valid = false
 				this.error.period.start.push(this.$t('stats.tooltips.error.dateFormat'))
+			}
+			// start time is no real date
+			if (isNaN(Date.parse(this.active.period.start))) {
+				valid = false
+				this.error.period.start.push(this.$t('stats.tooltips.error.dateUnreal'))
 			}
 			// end time is not set
 			if (!this.active.period.end) {
 				valid = false
 				this.error.period.end.push(this.$t('stats.tooltips.error.empty'))
 			}
-			// end time is no valid date
-			if (isNaN(Date.parse(this.active.period.end))) {
+			// end time is of wrong format
+			if (!datex.test(this.active.period.end)) {
 				valid = false
 				this.error.period.end.push(this.$t('stats.tooltips.error.dateFormat'))
+			}
+			// end time is no real date
+			if (isNaN(Date.parse(this.active.period.end))) {
+				valid = false
+				this.error.period.end.push(this.$t('stats.tooltips.error.dateUnreal'))
 			}
 			// start date is before end date
 			if (Date.parse(this.active.period.start) > Date.parse(this.active.period.end)) {

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -49,10 +49,25 @@
 					</div>
 					<!-- time period selection -->
 					<div class='filter-period d-flex ml-2'>
-						<label for='start' class='align-center text-gray p-0-5'>Time Period</label>
-						<div class="input-group d-flex">
-							<input type='text' v-model='active.period.start' @blur='formatPeriod("start")' placeholder='YYYY-MM-DD' id='start' class='align-stretch w-6' :class='{ error: error.period.start }' />
-							<input type='text' v-model='active.period.end' @blur='formatPeriod("end")' placeholder='YYYY-MM-DD' id='end' class='align-stretch w-6' :class='{ error: error.period.end }' />
+						<label for='start' class='align-center text-gray p-0-5'>{{ $t("stats.timePeriod") }}</label>
+						<div class='input-group d-flex align-stretch'>
+							<div
+								class='d-flex tooltip tooltip-bottom'
+								v-for='f in ["start", "end"]'
+								:key='f'
+								:data-tooltip='error.period[f].length > 0 ? error.period[f].join("\n") : $t("stats.tooltips.period." + f)'
+								:class='{ "tooltip-error": error.period[f].length > 0 }'
+							>
+								<input
+									type='text'
+									:id='f'
+									v-model='active.period[f]'
+									class='align-stretch w-6'
+									:class='{ error: error.period[f].length > 0 }'
+									placeholder='YYYY-MM-DD'
+									@blur='formatPeriod(f)'
+								/>
+							</div>
 							<button @click='updatePeriod' class='button-secondary align-center p-0-5'>
 								<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 24">
 									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
@@ -361,34 +376,34 @@ export default {
 	components: { LineChart, BarChart, HeatMap },
 	data () {
 		return {
-			accounts: [],     // list of all existing accounts
-			folders: [],      // list of all existing folders for the current account
+			accounts: [],    // list of all existing accounts
+			folders: [],     // list of all existing folders for the current account
 			active: {
-				account: null,  // currently selected account
-				folder: null,   // currently selected folder
+				account: null, // currently selected account
+				folder: null,  // currently selected folder
 				period: {
-					start: null,  // currently configured start of period of time
-					end: null,    // currently configured end of period of time
+					start: null, // currently configured start of period of time
+					end: null,   // currently configured end of period of time
 				}
 			},
 			error: {
 				period: {
-					start: false, // indicates if currently configured start of period of time is valid
-					end: false,   // indicates if currently configured end of period of time is valid
+					start: [],   // indicates if currently configured start of period of time is valid
+					end: [],     // indicates if currently configured end of period of time is valid
 				}
 			},
-			waiting: false,   // hides all charts and processes data in foreground
-			loading: false,   // keeps showing charts and processes data in background
-			display: {},      // processed data to show in foreground
-			store: {},        // data store for background processing (same structure as display)
-			tabs: {           // tab navigation containing one active tab
+			waiting: false,  // hides all charts and processes data in foreground
+			loading: false,  // keeps showing charts and processes data in background
+			display: {},     // processed data to show in foreground
+			store: {},       // data store for background processing (same structure as display)
+			tabs: {          // tab navigation containing one active tab
 				years: true,
 				quarters: false,
 				months: false,
 				weeks: false,
 			},
-			preferences: {    // preferences set for this page
-				sections: {     // preferences that can be set on this page
+			preferences: {   // preferences set for this page
+				sections: {    // preferences that can be set on this page
 					total: {
 						expand: false
 					},
@@ -399,7 +414,7 @@ export default {
 						leaderCount: 20
 					}
 				},
-				dark: true,     // preferences loaded from stored options
+				dark: true,    // preferences loaded from stored options
 				startOfWeek: 0,
 				localIdentities: [],
 				accounts: [],
@@ -727,8 +742,8 @@ export default {
 		resetPeriod: async function () {
 			this.active.period.start = null
 			this.active.period.end = null
-			this.error.period.start = false
-			this.error.period.end = false
+			this.error.period.start = []
+			this.error.period.end = []
 			this.preferences.sections.days.year = (new Date()).getFullYear()
 			if (this.active.folder) {
 			// reprocess current data if another filter is set
@@ -777,39 +792,33 @@ export default {
 		// returns true if entered time period is valid
 		validPeriod () {
 			let valid = true
-			// check start time
-			if (
-				// start time is not set
-				!this.active.period.start ||
-				// start time is no valid date
-				isNaN(Date.parse(this.active.period.start))
-			) {
+			this.error.period.start = []
+			this.error.period.end = []
+			// start time is not set
+			if (!this.active.period.start) {
 				valid = false
-				this.error.period.start = true
+				this.error.period.start.push(this.$t('stats.tooltips.error.empty'))
 			}
-			// check end time
-			if (
-				// end time is not set
-				!this.active.period.end ||
-				// end time is no valid date
-				isNaN(Date.parse(this.active.period.end))
-			) {
+			// start time is no valid date
+			if (isNaN(Date.parse(this.active.period.start))) {
 				valid = false
-				this.error.period.end = true
+				this.error.period.start.push(this.$t('stats.tooltips.error.dateFormat'))
 			}
-			// check both
-			if (
-				// start date is before end date
-				Date.parse(this.active.period.start) > Date.parse(this.active.period.end)
-			) {
+			// end time is not set
+			if (!this.active.period.end) {
 				valid = false
-				this.error.period.start = true
-				this.error.period.end = true
+				this.error.period.end.push(this.$t('stats.tooltips.error.empty'))
 			}
-			// remove previous errors if valid
-			if (valid) {
-				this.error.period.start = false
-				this.error.period.end = false
+			// end time is no valid date
+			if (isNaN(Date.parse(this.active.period.end))) {
+				valid = false
+				this.error.period.end.push(this.$t('stats.tooltips.error.dateFormat'))
+			}
+			// start date is before end date
+			if (Date.parse(this.active.period.start) > Date.parse(this.active.period.end)) {
+				valid = false
+				this.error.period.start.push(this.$t('stats.tooltips.error.dateOrderStart'))
+				this.error.period.end.push(this.$t('stats.tooltips.error.dateOrderEnd'))
 			}
 			return valid
 		}

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -39,7 +39,7 @@
 						<select v-model='active.folder' :disabled='waiting || loading' class='align-stretch w-6' :class='{ disabled: waiting || loading }' id='folder'>
 							<option v-for='f in folders' :key='f.path' :value='f'>{{ formatFolder(f) }}</option>
 						</select>
-						<div class='cursor-pointer tooltip tooltip-bottom d-inline-flex align-center' :data-tooltip='$t("stats.tooltips.clear")' @click='resetFolder'>
+						<div class='cursor-pointer tooltip tooltip-bottom d-inline-flex align-center' :data-tooltip='$t("stats.tooltips.clear")' @click='resetFolder(true)'>
 							<svg class='icon icon-bold icon-gray icon-hover-accent' viewBox='0 0 24 24'>
 								<path stroke='none' d='M0 0h24v24H0z' fill='none'/>
 								<line class='icon-part-accent2' x1='18' y1='6' x2='6' y2='18' />
@@ -75,7 +75,7 @@
 								</svg>
 							</button>
 						</div>
-						<div class='cursor-pointer tooltip tooltip-bottom d-inline-flex align-center' :data-tooltip='$t("stats.tooltips.clear")' @click='resetPeriod'>
+						<div class='cursor-pointer tooltip tooltip-bottom d-inline-flex align-center' :data-tooltip='$t("stats.tooltips.clear")' @click='resetPeriod(true)'>
 							<svg class='icon icon-bold icon-gray icon-hover-accent' viewBox='0 0 24 24'>
 								<path stroke='none' d='M0 0h24v24H0z' fill='none'/>
 								<line class='icon-part-accent2' x1='18' y1='6' x2='6' y2='18' />
@@ -718,15 +718,17 @@ export default {
 				await this.refresh(false)
 			}
 		},
-		// reset folder filter
-		resetFolder: async function () {
+		// reset folder filter, relaod data if requested
+		resetFolder: async function (reload) {
 			this.active.folder = null
-			if (this.active.period.start || this.active.period.end) {
-			// reprocess current data if another filter is set
-				await this.refresh(true)
-			} else {
-				// otherwise just load account data
-				await this.loadAccount(this.active.account)
+			if (reload) {
+				if (this.active.period.start || this.active.period.end) {
+					// reprocess current data if another filter is set
+					await this.refresh(true)
+				} else {
+					// otherwise just load account data
+					await this.loadAccount(this.active.account)
+				}
 			}
 		},
 		// process data for current time period filter
@@ -738,19 +740,21 @@ export default {
 				this.preferences.sections.days.year = (new Date(this.active.period.start)).getFullYear()
 			}
 		},
-		// reset time period filter
-		resetPeriod: async function () {
+		// reset time period filter, relaod data if requested
+		resetPeriod: async function (reload) {
 			this.active.period.start = null
 			this.active.period.end = null
 			this.error.period.start = []
 			this.error.period.end = []
 			this.preferences.sections.days.year = (new Date()).getFullYear()
-			if (this.active.folder) {
-			// reprocess current data if another filter is set
-				await this.refresh(true)
-			} else {
-				// otherwise just load account data
-				await this.loadAccount(this.active.account)
+			if (reload) {
+				if (this.active.folder) {
+					// reprocess current data if another filter is set
+					await this.refresh(true)
+				} else {
+					// otherwise just load account data
+					await this.loadAccount(this.active.account)
+				}
 			}
 		},
 		// activate tab of given <key>
@@ -1221,9 +1225,12 @@ export default {
 		}
 	},
 	watch: {
-		// on change of active account switch displayed data accordingly and reset filter
+		// on change of active account reset filter and switch displayed data accordingly
 		'active.account': async function (id) {
 			if (id) {
+				// reset filter
+				this.resetFolder(false)
+				this.resetPeriod(false)
 				// process data for given account
 				await this.loadAccount(id)
 			}

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -25,11 +25,11 @@
 							<svg class='icon icon-bold icon-gray icon-hover-accent' viewBox='0 0 24 24'>
 								<path stroke='none' d='M0 0h24v24H0z' fill='none'/>
 								<path class='icon-part-accent2' d='M9 4.55a8 8 0 0 1 6 14.9m0 -4.45v5h5' />
-								<line class='icon-part-accent2-dark' x1='5.63' y1='7.16' x2='5.63' y2='7.17' />
-								<line class='icon-part-accent2-dark' x1='4.06' y1='11' x2='4.06' y2='11.01' />
-								<line class='icon-part-accent2-dark' x1='4.63' y1='15.1' x2='4.63' y2='15.11' />
-								<line class='icon-part-accent2-dark' x1='7.16' y1='18.37' x2='7.16' y2='18.38' />
-								<line class='icon-part-accent2-dark' x1='11' y1='19.94' x2='11' y2='19.95' />
+								<line class='icon-part-accent2-faded' x1='5.63' y1='7.16' x2='5.63' y2='7.17' />
+								<line class='icon-part-accent2-faded' x1='4.06' y1='11' x2='4.06' y2='11.01' />
+								<line class='icon-part-accent2-faded' x1='4.63' y1='15.1' x2='4.63' y2='15.11' />
+								<line class='icon-part-accent2-faded' x1='7.16' y1='18.37' x2='7.16' y2='18.38' />
+								<line class='icon-part-accent2-faded' x1='11' y1='19.94' x2='11' y2='19.95' />
 							</svg>
 						</div>
 					</div>

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -323,6 +323,7 @@ textarea
 	border: solid 1px
 	border-radius: 2px
 	padding: .5rem
+	outline: none
 	transition: all transition.duration transition.function
 	&:focus
 		z-index: 50
@@ -481,18 +482,19 @@ textarea
 						background: mode.dark.highlight
 
 .input-group
-	&>*:hover
-		z-index: 25
-	&>*:first-child
-		border-top-right-radius: 0
-		border-bottom-right-radius: 0
-	&>*:last-child
-		border-top-left-radius: 0
-		border-bottom-left-radius: 0
-	&>*:not(:first-child)
-		margin-left: -1px
-	&>*:not(:first-child):not(:last-child)
-		border-radius: 0
+	& > *, & > * > input
+		&:hover, &:hover > input
+			z-index: 25
+		&:first-child, &:first-child > input
+			border-top-right-radius: 0
+			border-bottom-right-radius: 0
+		&:last-child, &:last-child > input
+			border-top-left-radius: 0
+			border-bottom-left-radius: 0
+		&:not(:first-child):not(:last-child), &:not(:first-child):not(:last-child) > input
+			border-radius: 0
+		&:not(:first-child)
+			margin-left: -1px
 
 // tabs
 .tab
@@ -584,3 +586,5 @@ loader(size, border)
 		&:focus, &:hover
 			&::after
 				transform: translate(-50%, .4rem)
+	&.tooltip-error::after
+		background: rgba(mode.dark.error, .75)

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -340,6 +340,7 @@ textarea
 			color: c.gray2
 			opacity: 1
 		.{m} &.error
+			z-index: 20
 			color: c.error
 			border-color: c.error
 			&:focus

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -13,6 +13,7 @@ mode = {
 		secondary2: #000000
 		shade:      #1d1d1f
 		icon:       #ffeb3b
+		error:      #c8295d
 	}
 	light: {
 		accent1:    #e64db9
@@ -27,6 +28,7 @@ mode = {
 		secondary2: #ffffff
 		shade:      #6d6d6f
 		icon:       #607d8b
+		error:      #c8295d
 	}
 }
 transition = {
@@ -337,6 +339,11 @@ textarea
 		.{m} &::placeholder
 			color: c.gray2
 			opacity: 1
+		.{m} &.error
+			color: c.error
+			border-color: c.error
+			&:focus
+				box-shadow: 0 0 0 .25rem rgba(c.error, .2)
 textarea
 	width: 100%
 	font-size: .9rem
@@ -470,6 +477,20 @@ textarea
 					border-color: c.accent2
 				~ .switch-handle
 						background: mode.dark.highlight
+
+.input-group
+	&>*:hover
+		z-index: 25
+	&>*:first-child
+		border-top-right-radius: 0
+		border-bottom-right-radius: 0
+	&>*:last-child
+		border-top-left-radius: 0
+		border-bottom-left-radius: 0
+	&>*:not(:first-child)
+		margin-left: -1px
+	&>*:not(:first-child):not(:last-child)
+		border-radius: 0
 
 // tabs
 .tab

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -344,6 +344,7 @@ textarea
 			color: c.error
 			border-color: c.error
 			&:focus
+				z-index: 50
 				box-shadow: 0 0 0 .25rem rgba(c.error, .2)
 textarea
 	width: 100%

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -255,12 +255,12 @@ for m, c in mode
 			&.icon-hover-accent:hover
 				.icon-part-accent1
 					stroke: c.accent1
-				.icon-part-accent1-dark
-					stroke: darken(c.accent1, 60%)
+				.icon-part-accent1-faded
+					stroke: rgba(c.accent1, .4)
 				.icon-part-accent2
 					stroke: c.accent2
-				.icon-part-accent2-dark
-					stroke: darken(c.accent2, 60%)
+				.icon-part-accent2-faded
+					stroke: rgba(c.accent2, .4)
 			&.icon-animated-color-transition
 				animation: unquote(m+ColorFading) 1s 0s infinite ease alternate
 
@@ -547,7 +547,7 @@ loader(size, border)
 			border-color: c.gray3
 			border-top-color: c.gray1
 			&.loader-accent2
-				border-color: darken(c.accent2, 60%)
+				border-color: rgba(c.accent2, .4)
 				border-top-color: c.accent2
 
 // tooltip


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Additional filter *time period*, adding 2 input fields for start and end date, an apply button and a reset button.
Since the date picker of TB is buggy (especially on the default dark theme), I decided to implement the input fields as normal text fields with autoformatting (completing century, inserting dashes). Time period also works in combination with the folder filter.

Date input must be of format YYYY-MM-DD (input of YYMMDD gets autocorrected). Date input can only be between 1970-01-01 and the current day (gets autocorrected). Start date must be before end date.

## Benefits

Ability to get all stats for a specific time period only.

![third-stats_filter_time_period](https://user-images.githubusercontent.com/5441654/102487441-dd649680-406a-11eb-8c66-25395f2dad79.gif)

## Applicable Issues

#161 

