### PR TITLE
Add ordinate option

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -121,6 +121,10 @@
       "label": "Dark Mode",
       "description": "Switch between dark and light color scheme"
     },
+    "ordinate": {
+      "label": "Vertical Axis",
+      "description": "Display vertical axis for all line and bar charts"
+    },
     "localIdentities": {
       "label": "Local Identities",
       "description": "A list of email addresses to recognize as 'sent from' for local accounts"

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -28,6 +28,20 @@
 			</section>
 			<!-- section related to the stats page -->
 			<h2 class='mt-3'>{{ $t('options.headings.stats') }}</h2>
+			<!-- option: ordinate -->
+			<section class='entry'>
+				<label for='ordinate'>
+					{{ $t('options.ordinate.label') }}
+					<span class='d-block text-gray text-small'>{{ $t('options.ordinate.description') }}</span>
+				</label>
+				<div class='action d-flex'>
+					<label class='switch'>
+						<input type='checkbox' id='ordinate' v-model='options.ordinate' />
+						<span class='switch-label' :data-on='$t("options.switch.on")' :data-off='$t("options.switch.off")'></span> 
+						<span class='switch-handle'></span> 
+					</label>
+				</div>
+			</section>
 			<!-- option: startOfWeek -->
 			<section class='entry'>
 				<label for='start'>
@@ -134,6 +148,7 @@ export default {
 			},
 			options: {
 				dark: true,
+				ordinate: false,
 				startOfWeek: 0,
 				addresses: '',
 				accounts: [],
@@ -153,10 +168,11 @@ export default {
 	},
 	methods: {
 		// create options object with given values or default values
-		optionsObject (dark, startOfWeek, addresses, accounts, cache) {
+		optionsObject (dark, ordinate, startOfWeek, addresses, accounts, cache) {
 			return {
 				options: {
 					dark: dark === null ? this.options.dark : dark,
+					ordinate: ordinate === null ? this.options.ordinate : ordinate,
 					startOfWeek: startOfWeek === null ? this.options.startOfWeek : startOfWeek,
 					addresses: addresses === null ? this.options.addresses : addresses,
 					accounts: accounts === null ? this.options.accounts : accounts,
@@ -210,7 +226,7 @@ export default {
 			if (this.input.address) {
 				let addresses = this.options.addresses ? this.options.addresses + ',' : ''
 				addresses += this.input.address
-				await messenger.storage.local.set(this.optionsObject(null, null, addresses, null, null))
+				await messenger.storage.local.set(this.optionsObject(null, null, null, addresses, null, null))
 				this.options.addresses = addresses
 				this.input.address = ''
 			}
@@ -220,7 +236,7 @@ export default {
 			let addresses = this.options.addresses.replace(address, '')
 			addresses = addresses.replace(/,,/g, ',')
 			addresses = addresses.replace(/^,+|,+$/g, '');
-			await messenger.storage.local.set(this.optionsObject(null, null, addresses, null, null))
+			await messenger.storage.local.set(this.optionsObject(null, null, null, addresses, null, null))
 			this.options.addresses = addresses
 		},
 		// clear all cached stats entries
@@ -228,7 +244,7 @@ export default {
 			// clear whole local storage
 			await messenger.storage.local.clear()
 			// restore options
-			await messenger.storage.local.set(this.optionsObject(null, null, null, null, null))
+			await messenger.storage.local.set(this.optionsObject(null, null, null, null, null, null))
 			// recalculate cache size
 			this.getCacheSize()
 		}
@@ -254,7 +270,7 @@ export default {
 	watch: {
 		options: {
 			handler: function () {
-				messenger.storage.local.set(this.optionsObject(null, null, null, null, null))
+				messenger.storage.local.set(this.optionsObject(null, null, null, null, null, null))
 			},
 			deep: true,
 			immediate: false

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -197,24 +197,28 @@
 								v-if='tabs.years'
 								:datasets='yearsChartData.datasets'
 								:labels='yearsChartData.labels'
+								:ordinate='preferences.ordinate'
 							/>
 							<!-- emails per quarter over total time -->
 							<LineChart
 								v-if='tabs.quarters'
 								:datasets='quartersChartData.datasets'
 								:labels='quartersChartData.labels'
+								:ordinate='preferences.ordinate'
 							/>
 							<!-- emails per month over total time -->
 							<LineChart
 								v-if='tabs.months'
 								:datasets='monthsChartData.datasets'
 								:labels='monthsChartData.labels'
+								:ordinate='preferences.ordinate'
 							/>
 							<!-- emails per week over total time -->
 							<LineChart
 								v-if='tabs.weeks'
 								:datasets='weeksChartData.datasets'
 								:labels='weeksChartData.labels'
+								:ordinate='preferences.ordinate'
 							/>
 						</div>
 					</div>
@@ -253,6 +257,7 @@
 						:description='$t("stats.charts.daytime.description")'
 						:datasets='daytimeChartData.datasets'
 						:labels='daytimeChartData.labels'
+						:ordinate='preferences.ordinate'
 					/>
 					<!-- emails per day of week -->
 					<BarChart
@@ -260,6 +265,7 @@
 						:description='$t("stats.charts.weekday.description")'
 						:datasets='weekdayChartData.datasets'
 						:labels='weekdayChartData.labels'
+						:ordinate='preferences.ordinate'
 					/>
 					<!-- emails per month of year -->
 					<BarChart
@@ -267,6 +273,7 @@
 						:description='$t("stats.charts.month.description")'
 						:datasets='monthChartData.datasets'
 						:labels='monthChartData.labels'
+						:ordinate='preferences.ordinate'
 					/>
 					<div class="chart-group">
 						<!-- emails per weekday per hour received -->
@@ -418,7 +425,8 @@ export default {
 				startOfWeek: 0,
 				localIdentities: [],
 				accounts: [],
-				cache: true
+				cache: true,
+				ordinate: false
 			},
 			publicPath: process.env.BASE_URL
 		}
@@ -718,7 +726,7 @@ export default {
 				await this.refresh(false)
 			}
 		},
-		// reset folder filter, relaod data if requested
+		// reset folder filter, reload data if requested
 		resetFolder: async function (reload) {
 			this.active.folder = null
 			if (reload) {
@@ -740,7 +748,7 @@ export default {
 				this.preferences.sections.days.year = (new Date(this.active.period.start)).getFullYear()
 			}
 		},
-		// reset time period filter, relaod data if requested
+		// reset time period filter, reload data if requested
 		resetPeriod: async function (reload) {
 			this.active.period.start = null
 			this.active.period.end = null

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -422,11 +422,11 @@ export default {
 					}
 				},
 				dark: true,    // preferences loaded from stored options
+				ordinate: false,
 				startOfWeek: 0,
 				localIdentities: [],
 				accounts: [],
 				cache: true,
-				ordinate: false
 			},
 			publicPath: process.env.BASE_URL
 		}
@@ -448,6 +448,7 @@ export default {
 			// only load options if they have been set, otherwise default settings will be kept
 			if (result && result.options) {
 				this.preferences.dark = result.options.dark ? true : false
+				this.preferences.ordinate = result.options.ordinate ? true : false
 				this.preferences.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
 				this.preferences.localIdentities = result.options.addresses ? result.options.addresses.split(',').map(x => x.trim()) : []
 				this.preferences.accounts = result.options.accounts ? result.options.accounts : []

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -17,6 +17,7 @@ export default {
 		labels: Array,
 		datasets: Array,
 		horizontal: Boolean,
+		ordinate: Boolean,
 	},
 	data () {
 		return {
@@ -71,7 +72,7 @@ export default {
 							}
 						}],
 						yAxes: [{
-							display: this.horizontal,
+							display: this.horizontal || this.ordinate,
 							stacked: false,
 							gridLines: {
 								display: false,

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -16,6 +16,7 @@ export default {
 		description: String,
 		labels: Array,
 		datasets: Array,
+		ordinate: Boolean
 	},
 	data () {
 		return {
@@ -70,7 +71,7 @@ export default {
 							}
 						}],
 						yAxes: [{
-							display: false,
+							display: this.ordinate,
 							stacked: false,
 							gridLines: {
 								display: false,


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Implements an option to show or hide the vertical axis for line and bar charts. It's deactivated by default, to maintain a cleaner UI.

## Benefits

Those who need the vertical axis values (e.g. for screenshots), can now easily activate it in the add-on options:

![image](https://user-images.githubusercontent.com/5441654/102545384-74a30b80-40b6-11eb-8f36-ca813253ae9a.png)

## Applicable Issues

#170
