### PR TITLE
❌ remove messages count from popup

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -6,7 +6,6 @@
     "account": "Account | Accounts",
     "folder": "Folder | Folders",
     "linkDescription": "Open all stats in new tab",
-    "messagesInFolder": "{0} messages in {1} folders",
     "message": "-"
   },
   "stats": {


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Removes the number of messages per account from the popup page.

## Benefits

This heavily increases loading time of the popup.

## Applicable Issues

#174
