### PR TITLE
Leader count option

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -161,7 +161,7 @@
     },
     "leaderCount": {
       "label": "Leader Count",
-      "description": "Number of entries shown in charts listing contacts (999 maximum)"
+      "description": "Number of entries shown in charts listing frequent contacts (999 maximum)"
     },
     "cache": {
       "label": "Activate Cache",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -161,7 +161,7 @@
     },
     "leaderCount": {
       "label": "Leader Count",
-      "description": "Number of contacts shown in 'Most received from' and 'Most sent to' charts"
+      "description": "Number of contacts shown in 'Most received from' and 'Most sent to' charts (999 maximum)"
     },
     "cache": {
       "label": "Activate Cache",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -161,7 +161,7 @@
     },
     "leaderCount": {
       "label": "Leader Count",
-      "description": "Number of contacts shown in 'Most received from' and 'Most sent to' charts (999 maximum)"
+      "description": "Number of entries shown in charts listing contacts (999 maximum)"
     },
     "cache": {
       "label": "Activate Cache",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -159,6 +159,10 @@
         "anyAccount": "Messages where sender and receiver are identities from any account will be excluded"
       }
     },
+    "leaderCount": {
+      "label": "Leader Count",
+      "description": "Number of contacts shown in 'Most received from' and 'Most sent to' charts"
+    },
     "cache": {
       "label": "Activate Cache",
       "description": "Enable caching system for faster display of already processed stats data."

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -128,7 +128,7 @@
 					<span class='d-block text-gray text-small'>{{ $t('options.leaderCount.description') }}</span>
 				</label>
 				<div class='action d-flex input-group'>
-					<input class='flex-grow' type='number' v-model='options.leaderCount' placeholder='20' min='1' max='999' maxlength='3' id='leaderCount' />
+					<input class='flex-grow' type='number' v-model='options.leaderCount' placeholder='20' min='1' max='999' id='leaderCount' />
 					<div class="d-flex flex-direction-column button-group-vertical">
 						<button @click='incrementLeaderCount()' class='h-1-25 py-0 px-0-5'>
 							<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -128,7 +128,7 @@
 					<span class='d-block text-gray text-small'>{{ $t('options.leaderCount.description') }}</span>
 				</label>
 				<div class='action d-flex input-group'>
-					<input class='flex-grow' type='text' v-model='options.leaderCount' placeholder='20' pattern='\d{1,3}' maxlength='3' id='leaderCount' />
+					<input class='flex-grow' type='number' v-model='options.leaderCount' placeholder='20' min='1' max='999' maxlength='3' id='leaderCount' />
 					<div class="d-flex flex-direction-column button-group-vertical">
 						<button @click='incrementLeaderCount()' class='h-1-25 py-0 px-0-5'>
 							<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -61,7 +61,7 @@
 					<span class='d-block text-gray text-small'>{{ $t('options.localIdentities.description') }}</span>
 				</label>
 				<div class='action'>
-					<div class="d-flex">
+					<div class="d-flex input-group">
 						<input class='flex-grow' type='email' v-model='input.address' placeholder='hello@devmount.de' id='local' />
 						<button @click='addAddress' class='p-0-5'>
 							<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 24">

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -62,7 +62,7 @@
 				</label>
 				<div class='action'>
 					<div class="d-flex">
-						<input  class='flex-grow' type='email' v-model='input.address' placeholder='hello@devmount.de' id='local' />
+						<input class='flex-grow' type='email' v-model='input.address' placeholder='hello@devmount.de' id='local' />
 						<button @click='addAddress' class='p-0-5'>
 							<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 24">
 								<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
@@ -119,6 +119,16 @@
 						</div>
 						<span class='text-small'>{{ $t('options.selfMessages.info.' + options.selfMessages) }}</span>
 					</div>
+				</div>
+			</section>
+			<!-- option: leaderCount -->
+			<section class='entry'>
+				<label for='leaderCount'>
+					{{ $t('options.leaderCount.label') }}
+					<span class='d-block text-gray text-small'>{{ $t('options.leaderCount.description') }}</span>
+				</label>
+				<div class='action d-flex'>
+					<input class='flex-grow' type='number' v-model='options.leaderCount' min='1' max='1000' placeholder='20' id='leaderCount' />
 				</div>
 			</section>
 			<!-- section related to store processed data -->
@@ -184,6 +194,7 @@ export default {
 				addresses: '',
 				accounts: [],
 				selfMessages: 'none',
+				leaderCount: 20,
 				cache: true,
 			},
 			allAccounts: [],
@@ -200,7 +211,7 @@ export default {
 	},
 	methods: {
 		// create options object with given values or default values
-		optionsObject (dark, ordinate, startOfWeek, addresses, accounts, selfMessages, cache) {
+		optionsObject (dark, ordinate, startOfWeek, addresses, accounts, selfMessages, leaderCount, cache) {
 			return {
 				options: {
 					dark: dark === null ? this.options.dark : dark,
@@ -209,6 +220,7 @@ export default {
 					addresses: addresses === null ? this.options.addresses : addresses,
 					accounts: accounts === null ? this.options.accounts : accounts,
 					selfMessages: selfMessages === null ? this.options.selfMessages : selfMessages,
+					leaderCount: leaderCount === null ? this.options.leaderCount : leaderCount,
 					cache: cache === null ? this.options.cache : cache,
 				}
 			}
@@ -260,7 +272,7 @@ export default {
 			if (this.input.address) {
 				let addresses = this.options.addresses ? this.options.addresses + ',' : ''
 				addresses += this.input.address
-				await messenger.storage.local.set(this.optionsObject(null, null, null, addresses, null, null, null))
+				await messenger.storage.local.set(this.optionsObject(null, null, null, addresses, null, null, null, null))
 				this.options.addresses = addresses
 				this.input.address = ''
 			}
@@ -270,7 +282,7 @@ export default {
 			let addresses = this.options.addresses.replace(address, '')
 			addresses = addresses.replace(/,,/g, ',')
 			addresses = addresses.replace(/^,+|,+$/g, '');
-			await messenger.storage.local.set(this.optionsObject(null, null, null, addresses, null, null, null))
+			await messenger.storage.local.set(this.optionsObject(null, null, null, addresses, null, null, null, null))
 			this.options.addresses = addresses
 		},
 		// clear all cached stats entries
@@ -278,7 +290,7 @@ export default {
 			// clear whole local storage
 			await messenger.storage.local.clear()
 			// restore options
-			await messenger.storage.local.set(this.optionsObject(null, null, null, null, null, null, null))
+			await messenger.storage.local.set(this.optionsObject(null, null, null, null, null, null, null, null))
 			// recalculate cache size
 			this.getCacheSize()
 		}
@@ -312,7 +324,7 @@ export default {
 	watch: {
 		options: {
 			handler: function () {
-				messenger.storage.local.set(this.optionsObject(null, null, null, null, null, null, null))
+				messenger.storage.local.set(this.optionsObject(null, null, null, null, null, null, null, null))
 			},
 			deep: true,
 			immediate: false

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -127,8 +127,20 @@
 					{{ $t('options.leaderCount.label') }}
 					<span class='d-block text-gray text-small'>{{ $t('options.leaderCount.description') }}</span>
 				</label>
-				<div class='action d-flex'>
-					<input class='flex-grow' type='number' v-model='options.leaderCount' min='1' max='1000' placeholder='20' id='leaderCount' />
+				<div class='action d-flex input-group'>
+					<input class='flex-grow' type='text' v-model='options.leaderCount' placeholder='20' pattern='\d{1,3}' maxlength='3' id='leaderCount' />
+					<div class="d-flex flex-direction-column button-group-vertical">
+						<button @click='incrementLeaderCount()' class='h-1-25 py-0 px-0-5'>
+							<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">
+								<polyline points="6,12 12,6 18,12" />
+							</svg>
+						</button>
+						<button @click='decrementLeaderCount()' class='h-1-25 py-0 px-0-5'>
+							<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">
+								<polyline points="6,5 12,11 18,5" />
+							</svg>
+						</button>
+					</div>
 				</div>
 			</section>
 			<!-- section related to store processed data -->
@@ -284,6 +296,18 @@ export default {
 			addresses = addresses.replace(/^,+|,+$/g, '');
 			await messenger.storage.local.set(this.optionsObject(null, null, null, addresses, null, null, null, null))
 			this.options.addresses = addresses
+		},
+		// increases leader count up to limit 999
+		incrementLeaderCount () {
+			if (this.options.leaderCount < 999) {
+				this.options.leaderCount++
+			}
+		},
+		// decreases leader count down to limit 1
+		decrementLeaderCount () {
+			if (this.options.leaderCount > 1) {
+				this.options.leaderCount--
+			}
 		},
 		// clear all cached stats entries
 		clearCache: async function () {

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -491,7 +491,7 @@ export default {
 						year: (new Date()).getFullYear()
 					},
 					contacts: {
-						leaderCount: 20
+						leaderCount: 1000
 					}
 				},
 				dark: true,    // preferences loaded from stored options

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -490,9 +490,6 @@ export default {
 					days: {
 						year: (new Date()).getFullYear()
 					},
-					contacts: {
-						leaderCount: 1000
-					}
 				},
 				dark: true,    // preferences loaded from stored options
 				ordinate: false,
@@ -500,6 +497,7 @@ export default {
 				localIdentities: [],
 				accounts: [],
 				selfMessages: 'none',
+				leaderCount: 20,
 				cache: true,
 			},
 			now: Date.now(), // property holding the current timestamp
@@ -588,6 +586,7 @@ export default {
 				this.preferences.localIdentities = result.options.addresses ? result.options.addresses.split(',').map(x => x.trim()) : []
 				this.preferences.accounts = result.options.accounts ? result.options.accounts : []
 				this.preferences.selfMessages = result.options.selfMessages ? result.options.selfMessages : 'none'
+				this.preferences.leaderCount = result.options.leaderCount ? result.options.leaderCount : 20
 				this.preferences.cache = result.options.cache ? true : false
 			}
 		},
@@ -628,8 +627,8 @@ export default {
 				self.progress.current++
 			})).then(() => {
 				// post processing: reduce size of contacts to configured limit
-				accountData.contacts.received = sortAndLimitObject(accountData.contacts.received, self.preferences.sections.contacts.leaderCount)
-				accountData.contacts.sent = sortAndLimitObject(accountData.contacts.sent, self.preferences.sections.contacts.leaderCount)
+				accountData.contacts.received = sortAndLimitObject(accountData.contacts.received, self.preferences.leaderCount)
+				accountData.contacts.sent = sortAndLimitObject(accountData.contacts.sent, self.preferences.leaderCount)
 				// post processing: add timestamp of finished processing
 				accountData.meta.timestamp = Date.now()
 			})
@@ -879,8 +878,8 @@ export default {
 					}
 				}
 				// contacts
-				sum.contacts.received = sortAndLimitObject(sumObjects(accountsData.reduce((p,c) => p.concat(c.contacts.received), [])), this.preferences.sections.contacts.leaderCount)
-				sum.contacts.sent = sortAndLimitObject(sumObjects(accountsData.reduce((p,c) => p.concat(c.contacts.sent), [])), this.preferences.sections.contacts.leaderCount)
+				sum.contacts.received = sortAndLimitObject(sumObjects(accountsData.reduce((p,c) => p.concat(c.contacts.received), [])), this.preferences.leaderCount)
+				sum.contacts.sent = sortAndLimitObject(sumObjects(accountsData.reduce((p,c) => p.concat(c.contacts.sent), [])), this.preferences.leaderCount)
 				// show summed stats
 				this.display = sum
 				// adjust displayed activity year

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -178,9 +178,15 @@ for m, c in mode
 	padding: .5rem
 .p-1
 	padding: 1rem
+.py-0
+	padding-top: 0
+	padding-bottom: 0
 .py-1
 	padding-top: 1rem
 	padding-bottom: 1rem
+.px-0-5
+	padding-left: .5rem
+	padding-right: .5rem
 .px-1
 	padding-left: 1rem
 	padding-right: 1rem
@@ -198,6 +204,8 @@ for m, c in mode
 	width: 100%
 .h-0-25
 	height: .25rem
+.h-1-25
+	height: 1.25rem
 .d-block
 	display: block
 .d-inline
@@ -208,6 +216,8 @@ for m, c in mode
 	display: flex
 .d-inline-flex
 	display: inline-flex
+.flex-direction-column
+	flex-direction: column
 .flex-grow
 	flex-grow: 1
 .flex-wrap
@@ -349,7 +359,6 @@ select
 input[type=text],
 input[type=email],
 input[type=date],
-input[type=number],
 textarea
 	appearance: none
 	border: solid 1px
@@ -516,19 +525,37 @@ textarea
 						background: mode.dark.highlight
 
 .input-group
-	& > *, & > * > input
-		&:hover, &:hover > input
+	& > *,
+	& > * > input
+		&:hover,
+		&:hover > input
 			z-index: 25
-		&:first-child, &:first-child > input
+		&:first-child,
+		&:first-child > input
 			border-top-right-radius: 0
 			border-bottom-right-radius: 0
-		&:last-child, &:last-child > input
+		&:last-child,
+		&:last-child > input
 			border-top-left-radius: 0
 			border-bottom-left-radius: 0
-		&:not(:first-child):not(:last-child), &:not(:first-child):not(:last-child) > input
+		&:not(:first-child):not(:last-child),
+		&:not(:first-child):not(:last-child) > input
 			border-radius: 0
 		&:not(:first-child)
 			margin-left: -1px
+
+.button-group-vertical
+	& > button
+		&:first-child
+			border-bottom-left-radius: 0
+			border-bottom-right-radius: 0
+		&:last-child
+			border-top-left-radius: 0
+			border-top-right-radius: 0
+	.input-group > &:last-child
+		& > button
+			border-top-left-radius: 0
+			border-bottom-left-radius: 0
 
 // tabs
 .tab

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -359,6 +359,7 @@ select
 input[type=text],
 input[type=email],
 input[type=date],
+input[type=number],
 textarea
 	appearance: none
 	border: solid 1px
@@ -393,6 +394,8 @@ textarea
 textarea
 	width: 100%
 	font-size: .9rem
+input[type=number]
+	-moz-appearance: textfield
 
 .checkbox
 	display: block

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -349,6 +349,7 @@ select
 input[type=text],
 input[type=email],
 input[type=date],
+input[type=number],
 textarea
 	appearance: none
 	border: solid 1px


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Adds option to define the number of entries in leaderboards. Allowed are numbers between 1 and 999 due to reasonable cache size.

## Benefits

No hardcoded number of contacts anymore.
![image](https://user-images.githubusercontent.com/5441654/104023559-228b6c80-51c2-11eb-86e1-c97b87e92a34.png)

## Applicable Issues

Closes #183 
