### PR TITLE
🔨 extend parameter handling for invalid cases

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -604,7 +604,9 @@ export default {
 			this.identities = accounts.reduce((p,c) => p.concat(c.identities.map(i => i.email)), [])
 			// extract account id from url GET parameter
 			let uri = window.location.search.substring(1)
-			this.active.account = (new URLSearchParams(uri)).get('s')
+			let id = (new URLSearchParams(uri)).get('s')
+			if (!id || (id == 'sum' && !this.preferences.cache)) id = accounts[0].id
+			this.active.account = id
 		},
 		// analyze folders of a given account <a>
 		// return processed data oject structured like initData


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

If URL parameter which holds the account ID is invalid (e.g. not given at all or all accounts processing was requested without Cache being enabled), the first account of the available accounts list is displayed on the stats page.

## Applicable Issues

Fixes #208 B)
