### PR TITLE
🔨 fix initial account lists

### DIFF
--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -72,9 +72,12 @@ export default {
 		// add folder count to account object
 		async getAccounts () {
 			let accounts = await messenger.accounts.list()
-			// filter list of accounts if user configured custom list
 			if (this.options.accounts.length > 0) {
+				// filter list of accounts if user configured custom list
 				accounts = accounts.filter(a => this.options.accounts.includes(a.id))
+			} else {
+				// default accounts activated are all non local accounts ...
+				accounts = accounts.filter(a => a.type != 'none')
 			}
 			// calculate folder and message count and append to account object
 			let self = this

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -594,9 +594,12 @@ export default {
 		// get active account from URL get parameter
 		async getAccounts () {
 			let accounts = await messenger.accounts.list()
-			// filter list of accounts if user configured custom list
 			if (this.preferences.accounts.length > 0) {
+				// filter list of accounts if user configured custom list
 				accounts = accounts.filter(a => this.preferences.accounts.includes(a.id))
+			} else {
+				// default accounts activated are all non local accounts ...
+				accounts = accounts.filter(a => a.type != 'none')
 			}
 			// assign accounts
 			this.accounts = accounts


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Account lists in the popup menu and on the stats page were initially listing all accounts, instead of the default setting of listing all non local accounts. This lead to unexpected behaviour for users with only one local and one non-local account.

## Applicable Issues

#208 
