### PR TITLE
💚 switch from flex to grid for popup account tiles

### DIFF
--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -129,12 +129,10 @@ html, body
 		.loading
 			loader 16px 3px
 		.accounts
-			display: flex
-			flex-wrap: wrap
-			justify-content: space-between
-			row-gap: 20px
+			display: grid
+			grid-template-columns: 1fr 1fr
+			gap: 20px
 			& > div
-				width: 8rem
 				padding: .75rem 1rem
 				border-radius: 4px
 				transition: all .2s


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

A users has unwanted 1 column layout in the popup menu. This PR switches the Flex to the grid layout to always show two column account tiles.

## Benefits

No unwanted wrapping.

## Applicable Issues

None yet.
