### PR TITLE
🔨 fix switch and checkbox elements size on options page

### DIFF
--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -425,6 +425,7 @@ input[type=number]
 		display: inline-block
 		position: absolute
 		transition: all transition.duration transition.function
+		box-sizing: border-box
 	input
 		clip: rect(0, 0, 0, 0)
 		height: 1px
@@ -481,6 +482,7 @@ input[type=number]
 		text-transform: uppercase
 		border-radius: inherit
 		transition: inherit
+		box-sizing: border-box
 		&::before, &::after
 			position: absolute
 			top: 45%


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change
Switches and Checkboxes were 1px too tall on options page

## Benefits
Fix this by applying including border size.

## Applicable Issues

None.
