### PR TITLE
🔨 add local identities to global identities list

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -617,8 +617,12 @@ export default {
 			}
 			// assign accounts
 			this.accounts = accounts
-			// assign identities
-			this.identities = accounts.reduce((p,c) => p.concat(c.identities.map(i => i.email)), [])
+			// assign identities of all activated accounts as well as localIdentities if any local account is active
+			let identities = accounts.reduce((p,c) => p.concat(c.identities.map(i => i.email)), [])
+			if (accounts.some(a => a.type == 'none')) {
+				identities = identities.concat(this.preferences.localIdentities)
+			}
+			this.identities = identities
 			// extract account id from url GET parameter
 			let uri = window.location.search.substring(1)
 			let id = (new URLSearchParams(uri)).get('s')


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

When option *Self Messages* was set to "From Any Account", local identities were not being taken into account if a local account was active.

## Benefits

This PR includes configured local identities for this option.

## Applicable Issues

None.
