### PR TITLE
Properly handle one account list

### DIFF
--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -10,7 +10,7 @@
 				<div
 					class='text-hover-accent2 cursor-pointer tooltip tooltip-left transition-color'
 					:data-tooltip='$t("popup.openAllStats")'
-					@click.prevent="openTab('stats.html', 'sum')"
+					@click.prevent="openTab('stats.html', accounts.length > 1 ? 'sum' : accounts[0].id)"
 				>
 					<svg class='icon icon-thin icon-small ml-auto' viewBox="0 0 24 24">
 						<path stroke='none' d='M0 0h24v24H0z' fill='none'/>

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -626,7 +626,7 @@ export default {
 			// extract account id from url GET parameter
 			let uri = window.location.search.substring(1)
 			let id = (new URLSearchParams(uri)).get('s')
-			if (!id || (id == 'sum' && !this.preferences.cache)) id = accounts[0].id
+			if (!id || (id == 'sum' && !this.preferences.cache) || (id == 'sum' && accounts.length <= 1)) id = accounts[0].id
 			this.active.account = id
 		},
 		// analyze folders of a given account <a>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change
This change hardens the handling of the case, when a user only has one activated account. The "Open all stats" in the popup menu now points to this single account in that case. Also a reload of the stats page with `s=sum` shows that account properly instead of an empty account select field.
