### PR TITLE
 Aim for a bit more nerdyness & a tiny bit cleanness 😉

### DIFF
--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -107,7 +107,7 @@
       "minute": "min",
       "second": "s"
     },
-    "starAndImprove": "Sei ein Weltverbesserer, auf <a href='{0}' target='_blank'>GitHub</a>".,
+    "starAndImprove": "Mach mich zum Star, auf <a href='{0}' target='_blank'>GitHub</a>.",
     "message": "-",
     "allAccountsSum": "Alle Konten (Summe)",
     "dataCollected": "Daten vor {0} abgerufen"

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -107,7 +107,7 @@
       "minute": "min",
       "second": "s"
     },
-    "starAndImprove": "Beteilige dich an diesem Projekt auf <a href='{0}' target='_blank'>Github</a>",
+    "starAndImprove": "Sei ein Weltverbesserer, auf <a href='{0}' target='_blank'>GitHub</a>".,
     "message": "-",
     "allAccountsSum": "Alle Konten (Summe)",
     "dataCollected": "Daten vor {0} abgerufen"

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -109,7 +109,7 @@
       "minute": "min",
       "second": "s"
     },
-    "starAndImprove": "Star and improve this project on <a href='{0}' target='_blank'>Github</a>",
+    "starAndImprove": "Be a star, fork me on <a href='{0}' target='_blank'>GitHub</a>.",
     "message": "-"
   },
   "options": {

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -383,7 +383,7 @@
 			<!-- footer -->
 			<footer class="mt-6 text-center">
 				<div class='text-gray'>
-					<span class='text-middle mr-1'>ThirdStats v{{ appVersion }}</span>
+					<span class='text-middle mr-1'>ThirdStats {{ appVersion }}</span>
 					<svg
 						v-if='preferences.dark'
 						class='icon icon-dark icon-text icon-thin d-inline text-middle cursor-pointer'


### PR DESCRIPTION
## Description of the Change

Most "join & help improve the statements, especially those linking to GitHub, use that "Fork me on GitHub" banner.
I aimed for a bit more fun here, at least for DE & EN locales, by targeting a latent ambiguity, with a wink one might say. 😄

Additionally, being a UI aesthetics junky, I removed the "v" in front of ThirdStats's version line at the stats page's bottom - looks cleaner now. Target accomplished. 😎 If the owner approves my PR, that is. 😅

## Benefits

No vaccine against COVID-19, I guess. 😞
But a bit more joy, hence - maybe, in a galaxy far, far away - world peace? 🤔

## Applicable Issues

None, was entirely done out of joy about my discovery that GitHub, in 2021, *_finally_* supports dark-mode! 😍🥳🤘🏻