### PR TITLE
Popup stats

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -5,6 +5,7 @@
   "popup": {
     "account": "Account | Accounts",
     "folder": "Folder | Folders",
+    "messages": "Message | Messages",
     "openAllStats": "Open all Stats",
     "openOptions": "Open Options",
     "message": "-"

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -247,6 +247,7 @@
 								:datasets='yearsChartData.datasets'
 								:labels='yearsChartData.labels'
 								:ordinate='preferences.ordinate'
+								:abscissa='true'
 							/>
 							<!-- emails per quarter over total time -->
 							<LineChart
@@ -254,6 +255,7 @@
 								:datasets='quartersChartData.datasets'
 								:labels='quartersChartData.labels'
 								:ordinate='preferences.ordinate'
+								:abscissa='true'
 							/>
 							<!-- emails per month over total time -->
 							<LineChart
@@ -261,6 +263,7 @@
 								:datasets='monthsChartData.datasets'
 								:labels='monthsChartData.labels'
 								:ordinate='preferences.ordinate'
+								:abscissa='true'
 							/>
 							<!-- emails per week over total time -->
 							<LineChart
@@ -268,6 +271,7 @@
 								:datasets='weeksChartData.datasets'
 								:labels='weeksChartData.labels'
 								:ordinate='preferences.ordinate'
+								:abscissa='true'
 							/>
 						</div>
 					</div>

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -254,6 +254,10 @@ for m, c in mode
 	right: 0
 .right-0-5
 	right: .5rem
+.z-0
+	z-index: 0
+.z-5
+	z-index: 5
 
 // visibility
 .v-hidden

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -2,7 +2,13 @@
 <div class='chart'>
 	<h2 v-if='title' class='text-center'>{{ title }}</h2>
 	<p v-if='description' class='text-gray text-center'>{{ description }}</p>
-	<div class="chart-container">
+	<div
+		class="chart-container"
+		:style="{
+			width: this.width ? this.width : 'auto',
+			height: this.height ? this.height : 'auto'
+		}"
+	>
 		<canvas :id='id'></canvas>
 	</div>
 </div>
@@ -16,7 +22,10 @@ export default {
 		description: String,
 		labels: Array,
 		datasets: Array,
-		ordinate: Boolean
+		ordinate: Boolean,
+		abscissa: Boolean,
+		width: String,
+		height: String,
 	},
 	data () {
 		return {
@@ -60,6 +69,7 @@ export default {
 					maintainAspectRatio: false,
 					scales: {
 						xAxes: [{
+							display: this.abscissa,
 							stacked: false,
 							gridLines: {
 								display: false,


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change adds the overall messages count to the popup menu account tiles again. It also adds a background chart showing the annual progression of all messages (sum of sent and received messages). The data only shows up, if cache is enabled and cached date already exists for the corresponding account.

To prevent an overload of content in the account tiles and save clearness, no more metrics were added.

## Benefits

Quick overview of accounts messages count in the popup menu again after #178.

![image](https://user-images.githubusercontent.com/5441654/105630453-a774b800-5e49-11eb-9725-1e44fe8ccb05.png)

## Applicable Issues

#175 