### PR TITLE
🔨 set account name in tab title of stats page again

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -947,6 +947,8 @@ export default {
 			} else {
 				// load single account from id
 				let account = await messenger.accounts.get(id)
+				// set tab title
+				document.title = 'ThirdStats: ' + account.name
 				// (re)calculate list of folders
 				this.folders = traverseAccount(account)
 				// only check storage if no refresh was requested cache is enabled


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Tab titles with account name for single accounts on the stats page were missing.

## Benefits

More speaking Tab titles again.

## Applicable Issues
None
