### PR TITLE
Improve stats page layout

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -47,10 +47,7 @@
       },
       "days": {
         "title": "Activity in {0}",
-        "description": {
-          "received": "Number of incoming emails per day",
-          "sent": "Number of outgoing emails per day"
-        }
+        "description": "Number of emails per single date"
       },
       "daytime": {
         "title": "Daytime",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -63,10 +63,7 @@
       },
       "temporalDistribution": {
         "title": "Temporal distribution",
-        "description": {
-          "received": "Number of incoming emails per weekday per hour",
-          "sent": "Number of outgoing emails per weekday per hour"
-        }
+        "description": "Number of emails per weekday per hour"
       },
       "leader": {
         "title": {

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -426,7 +426,7 @@
 							/>
 							<!-- contacts most emails sent to -->
 							<BarChart
-								v-if='tabs.leader.timePassedSinceDataRetrieval'
+								v-if='tabs.leader.sent'
 								:datasets='sentContactLeadersChartData.datasets'
 								:labels='sentContactLeadersChartData.labels'
 								:horizontal='true'

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -368,29 +368,40 @@
 							/>
 						</div>
 					</div>
-					<div class="chart-group">
-						<!-- emails per weekday per hour received -->
-						<HeatMap
-							:title='$t("stats.charts.temporalDistribution.title")'
-							:description='$t("stats.charts.temporalDistribution.description.received")'
-							rgb='10, 132, 255'
-							spacing='1px'
-							rounding='5px'
-							:dataset='weekdayPerHourChartData.received'
-							:labels='{ y: weekdayPerHourChartData.labels, x: Array.from(Array(24).keys())}'
-							:tooltips='"{y}, {x}:00\n{label}: {value}"'
-							class='mb-0-5'
-						/>
-						<!-- emails per weekday per hour sent -->
-						<HeatMap
-							:description='$t("stats.charts.temporalDistribution.description.sent")'
-							rgb='230, 77, 185'
-							spacing='1px'
-							rounding='5px'
-							:dataset='weekdayPerHourChartData.sent'
-							:labels='{ y: weekdayPerHourChartData.labels, x: Array.from(Array(24).keys())}'
-							:tooltips='"{y}, {x}:00\n{label}: {value}"'
-						/>
+					<div class='tab-area'>
+						<ul class='tab'>
+							<li
+								v-for='(active, label) in tabs.twodim'
+								:key='label'
+								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								:data-tooltip='$t("stats.charts." + label + ".description")'
+								:class='{ "active": active }'
+								@click='activateTab("twodim", label)'
+							>
+								<span>{{ $t('stats.charts.' + label + '.title') }}</span>
+							</li>
+						</ul>
+						<div class="tab-content chart-group mt-1">
+							<!-- emails per weekday per hour received -->
+							<HeatMap
+								rgb='10, 132, 255'
+								spacing='1px'
+								rounding='5px'
+								:dataset='weekdayPerHourChartData.received'
+								:labels='{ y: weekdayPerHourChartData.labels, x: Array.from(Array(24).keys())}'
+								:tooltips='"{y}, {x}:00\n{label}: {value}"'
+								class='mt-1-5 mb-1-5'
+							/>
+							<!-- emails per weekday per hour sent -->
+							<HeatMap
+								rgb='230, 77, 185'
+								spacing='1px'
+								rounding='5px'
+								:dataset='weekdayPerHourChartData.sent'
+								:labels='{ y: weekdayPerHourChartData.labels, x: Array.from(Array(24).keys())}'
+								:tooltips='"{y}, {x}:00\n{label}: {value}"'
+							/>
+						</div>
 					</div>
 					<!-- contacts most emails received from -->
 					<BarChart
@@ -548,6 +559,9 @@ export default {
 					daytime: true,
 					weekday: false,
 					month: false,
+				},
+				twodim: {
+					temporalDistribution: true,
 				}
 			},
 			preferences: {   // preferences set for this page

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -331,30 +331,43 @@
 					</div>
 				</div>
 				<div id='chart-area-main' class='chart-area mt-2'>
-					<!-- emails per time of day -->
-					<BarChart
-						:title='$t("stats.charts.daytime.title")'
-						:description='$t("stats.charts.daytime.description")'
-						:datasets='daytimeChartData.datasets'
-						:labels='daytimeChartData.labels'
-						:ordinate='preferences.ordinate'
-					/>
-					<!-- emails per day of week -->
-					<BarChart
-						:title='$t("stats.charts.weekday.title")'
-						:description='$t("stats.charts.weekday.description")'
-						:datasets='weekdayChartData.datasets'
-						:labels='weekdayChartData.labels'
-						:ordinate='preferences.ordinate'
-					/>
-					<!-- emails per month of year -->
-					<BarChart
-						:title='$t("stats.charts.month.title")'
-						:description='$t("stats.charts.month.description")'
-						:datasets='monthChartData.datasets'
-						:labels='monthChartData.labels'
-						:ordinate='preferences.ordinate'
-					/>
+					<div class='tab-area'>
+						<ul class='tab'>
+							<li
+								v-for='(active, label) in tabs.onedim'
+								:key='label'
+								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								:data-tooltip='$t("stats.charts." + label + ".description")'
+								:class='{ "active": active }'
+								@click='activateTab("onedim", label)'
+							>
+								<span>{{ $t('stats.charts.' + label + '.title') }}</span>
+							</li>
+						</ul>
+						<div class='tab-content mt-1'>
+							<!-- emails per time of day -->
+							<BarChart
+								v-if='tabs.onedim.daytime'
+								:datasets='daytimeChartData.datasets'
+								:labels='daytimeChartData.labels'
+								:ordinate='preferences.ordinate'
+							/>
+							<!-- emails per day of week -->
+							<BarChart
+								v-if='tabs.onedim.weekday'
+								:datasets='weekdayChartData.datasets'
+								:labels='weekdayChartData.labels'
+								:ordinate='preferences.ordinate'
+							/>
+							<!-- emails per month of year -->
+							<BarChart
+								v-if='tabs.onedim.month'
+								:datasets='monthChartData.datasets'
+								:labels='monthChartData.labels'
+								:ordinate='preferences.ordinate'
+							/>
+						</div>
+					</div>
 					<div class="chart-group">
 						<!-- emails per weekday per hour received -->
 						<HeatMap
@@ -530,6 +543,11 @@ export default {
 				},
 				activity: {
 					days: true,
+				},
+				onedim: {
+					daytime: true,
+					weekday: false,
+					month: false,
 				}
 			},
 			preferences: {   // preferences set for this page

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -403,22 +403,36 @@
 							/>
 						</div>
 					</div>
-					<!-- contacts most emails received from -->
-					<BarChart
-						:title='$t("stats.charts.leader.title.received")'
-						:description='$t("stats.charts.leader.description.received")'
-						:datasets='receivedContactLeadersChartData.datasets'
-						:labels='receivedContactLeadersChartData.labels'
-						:horizontal='true'
-					/>
-					<!-- contacts most emails sent to -->
-					<BarChart
-						:title='$t("stats.charts.leader.title.sent")'
-						:description='$t("stats.charts.leader.description.sent")'
-						:datasets='sentContactLeadersChartData.datasets'
-						:labels='sentContactLeadersChartData.labels'
-						:horizontal='true'
-					/>
+					<div class='tab-area'>
+						<ul class='tab'>
+							<li
+								v-for='(active, label) in tabs.leader'
+								:key='label'
+								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								:data-tooltip='$t("stats.charts.leader.description." + label)'
+								:class='{ "active": active }'
+								@click='activateTab("leader", label)'
+							>
+								<span>{{ $t('stats.charts.leader.title.' + label) }}</span>
+							</li>
+						</ul>
+						<div class="tab-content mt-1">
+							<!-- contacts most emails received from -->
+							<BarChart
+								v-if='tabs.leader.received'
+								:datasets='receivedContactLeadersChartData.datasets'
+								:labels='receivedContactLeadersChartData.labels'
+								:horizontal='true'
+							/>
+							<!-- contacts most emails sent to -->
+							<BarChart
+								v-if='tabs.leader.timePassedSinceDataRetrieval'
+								:datasets='sentContactLeadersChartData.datasets'
+								:labels='sentContactLeadersChartData.labels'
+								:horizontal='true'
+							/>
+						</div>
+					</div>
 				</div>
 			</section>
 			<!-- footer -->
@@ -562,6 +576,10 @@ export default {
 				},
 				twodim: {
 					temporalDistribution: true,
+				},
+				leader: {
+					received: true,
+					sent: false,
 				}
 			},
 			preferences: {   // preferences set for this page

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -134,8 +134,6 @@
 					v-html='$t("stats.dataCollected", ["<span class=\"text-normal\">" + timePassedSinceDataRetrieval + "</span>"])'
 				></div>
 			</section>
-			<!-- heading: general -->
-			<h2>General</h2>
 			<!-- fetured numbers -->
 			<section class='numbers mx-auto mt-2'>
 				<!-- total -->
@@ -210,12 +208,12 @@
 							<li
 								v-for='(active, label) in tabs.total'
 								:key='label'
-								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								class='tab-item cursor-default tooltip tooltip-bottom'
 								:data-tooltip='$t("stats.charts." + label + ".description")'
-								:class='{ "active": active }'
+								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("total", label)'
 							>
-								<span>{{ $t('stats.charts.' + label + '.title') }}</span>
+								<span class="transition-color transition-border-color">{{ $t('stats.charts.' + label + '.title') }}</span>
 							</li>
 							<li
 								class='resizer cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto'
@@ -299,12 +297,12 @@
 							<li
 								v-for='(active, label) in tabs.activity'
 								:key='label'
-								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								class='tab-item cursor-default tooltip tooltip-bottom'
 								:data-tooltip='$t("stats.charts." + label + ".description")'
-								:class='{ "active": active }'
+								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("activity", label)'
 							>
-								<span>{{ $t('stats.charts.' + label + '.title', [preferences.sections.days.year]) }}</span>
+								<span class="transition-color transition-border-color">{{ $t('stats.charts.' + label + '.title', [preferences.sections.days.year]) }}</span>
 							</li>
 						</ul>
 						<div class='tab-content chart-group mt-1'>
@@ -336,12 +334,12 @@
 							<li
 								v-for='(active, label) in tabs.onedim'
 								:key='label'
-								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								class='tab-item cursor-default tooltip tooltip-bottom'
 								:data-tooltip='$t("stats.charts." + label + ".description")'
-								:class='{ "active": active }'
+								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("onedim", label)'
 							>
-								<span>{{ $t('stats.charts.' + label + '.title') }}</span>
+								<span class="transition-color transition-border-color">{{ $t('stats.charts.' + label + '.title') }}</span>
 							</li>
 						</ul>
 						<div class='tab-content mt-1'>
@@ -373,12 +371,12 @@
 							<li
 								v-for='(active, label) in tabs.twodim'
 								:key='label'
-								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								class='tab-item cursor-default tooltip tooltip-bottom'
 								:data-tooltip='$t("stats.charts." + label + ".description")'
-								:class='{ "active": active }'
+								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("twodim", label)'
 							>
-								<span>{{ $t('stats.charts.' + label + '.title') }}</span>
+								<span class="transition-color transition-border-color">{{ $t('stats.charts.' + label + '.title') }}</span>
 							</li>
 						</ul>
 						<div class="tab-content chart-group mt-1">
@@ -408,12 +406,12 @@
 							<li
 								v-for='(active, label) in tabs.leader'
 								:key='label'
-								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								class='tab-item cursor-default tooltip tooltip-bottom'
 								:data-tooltip='$t("stats.charts.leader.description." + label)'
-								:class='{ "active": active }'
+								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("leader", label)'
 							>
-								<span>{{ $t('stats.charts.leader.title.' + label) }}</span>
+								<span class="transition-color transition-border-color">{{ $t('stats.charts.leader.title.' + label) }}</span>
 							</li>
 						</ul>
 						<div class="tab-content mt-1">

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -1603,7 +1603,7 @@ body
 		@media (min-width: 2501px)
 			max-width: 2500px
 			#chart-area-main
-				grid-template-columns: repeat(6, 1fr)
+				grid-template-columns: repeat(4, 1fr)
 		@media (max-width: 2500px)
 			max-width: 2200px
 			#chart-area-main

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -134,6 +134,8 @@
 					v-html='$t("stats.dataCollected", ["<span class=\"text-normal\">" + timePassedSinceDataRetrieval + "</span>"])'
 				></div>
 			</section>
+			<!-- heading: general -->
+			<h2>General</h2>
 			<!-- fetured numbers -->
 			<section class='numbers mx-auto mt-2'>
 				<!-- total -->
@@ -206,12 +208,12 @@
 					<div class='tab-area'>
 						<ul class='tab'>
 							<li
-								v-for='(active, label) in tabs'
+								v-for='(active, label) in tabs.total'
 								:key='label'
 								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
 								:data-tooltip='$t("stats.charts." + label + ".description")'
 								:class='{ "active": active }'
-								@click='activateTab(label)'
+								@click='activateTab("total", label)'
 							>
 								<span>{{ $t('stats.charts.' + label + '.title') }}</span>
 							</li>
@@ -243,7 +245,7 @@
 						<div class='tab-content mt-1'>
 							<!-- emails per year over total time -->
 							<LineChart
-								v-if='tabs.years'
+								v-if='tabs.total.years'
 								:datasets='yearsChartData.datasets'
 								:labels='yearsChartData.labels'
 								:ordinate='preferences.ordinate'
@@ -251,7 +253,7 @@
 							/>
 							<!-- emails per quarter over total time -->
 							<LineChart
-								v-if='tabs.quarters'
+								v-if='tabs.total.quarters'
 								:datasets='quartersChartData.datasets'
 								:labels='quartersChartData.labels'
 								:ordinate='preferences.ordinate'
@@ -259,7 +261,7 @@
 							/>
 							<!-- emails per month over total time -->
 							<LineChart
-								v-if='tabs.months'
+								v-if='tabs.total.months'
 								:datasets='monthsChartData.datasets'
 								:labels='monthsChartData.labels'
 								:ordinate='preferences.ordinate'
@@ -267,7 +269,7 @@
 							/>
 							<!-- emails per week over total time -->
 							<LineChart
-								v-if='tabs.weeks'
+								v-if='tabs.total.weeks'
 								:datasets='weeksChartData.datasets'
 								:labels='weeksChartData.labels'
 								:ordinate='preferences.ordinate'
@@ -508,11 +510,13 @@ export default {
 				max: 0,        // upper limit for progress indicator
 			},
 			display: {},     // processed data to show
-			tabs: {          // tab navigation containing one active tab
-				years: true,
-				quarters: false,
-				months: false,
-				weeks: false,
+			tabs: {          // tab navigation containing one active tab at a time
+				total: {
+					years: true,
+					quarters: false,
+					months: false,
+					weeks: false,
+				},
 			},
 			preferences: {   // preferences set for this page
 				sections: {    // preferences that can be set on this page
@@ -1003,11 +1007,10 @@ export default {
 			}
 		},
 		// tab navigation
-		// activate tab of given <key>
-		activateTab (key) {
+		// activate tab of given <position> in given <area>
+		activateTab (area, position) {
 			let self = this
-			Object.keys(this.tabs).map(t => self.tabs[t] = false)
-			this.tabs[key] = true
+			Object.keys(this.tabs[area]).map(t => self.tabs[area][t] = t == position)
 		},
 		// format folder select options
 		// build <folder> name to match its hierarchy with preceding dashes
@@ -1586,6 +1589,9 @@ body
 					margin: 4px 4px 4px 7px
 				.refresh
 					margin-left: 3px
+		
+		&>h2
+			font-weight: 300
 
 		.numbers
 			display: grid

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -208,12 +208,14 @@
 							<li
 								v-for='(active, label) in tabs.total'
 								:key='label'
-								class='tab-item cursor-default tooltip tooltip-bottom'
+								class='tab-item cursor-default tooltip tooltip-bottom border-bottom-accent2'
 								:data-tooltip='$t("stats.charts." + label + ".description")'
 								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("total", label)'
 							>
-								<span class="transition-color transition-border-color">{{ $t('stats.charts.' + label + '.title') }}</span>
+								<span class="transition-color transition-border-image border-bottom-gradient-accent2-accent1">
+									{{ $t('stats.charts.' + label + '.title') }}
+								</span>
 							</li>
 							<li
 								class='resizer cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto'
@@ -302,7 +304,9 @@
 								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("activity", label)'
 							>
-								<span class="transition-color transition-border-color">{{ $t('stats.charts.' + label + '.title', [preferences.sections.days.year]) }}</span>
+								<span class="transition-color transition-border-image border-bottom-gradient-accent2-accent1">
+									{{ $t('stats.charts.' + label + '.title', [preferences.sections.days.year]) }}
+								</span>
 							</li>
 						</ul>
 						<div class='tab-content chart-group mt-1'>
@@ -339,7 +343,9 @@
 								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("onedim", label)'
 							>
-								<span class="transition-color transition-border-color">{{ $t('stats.charts.' + label + '.title') }}</span>
+								<span class="transition-color transition-border-image border-bottom-gradient-accent2-accent1">
+									{{ $t('stats.charts.' + label + '.title') }}
+								</span>
 							</li>
 						</ul>
 						<div class='tab-content mt-1'>
@@ -376,7 +382,9 @@
 								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("twodim", label)'
 							>
-								<span class="transition-color transition-border-color">{{ $t('stats.charts.' + label + '.title') }}</span>
+								<span class="transition-color transition-border-image border-bottom-gradient-accent2-accent1">
+									{{ $t('stats.charts.' + label + '.title') }}
+								</span>
 							</li>
 						</ul>
 						<div class="tab-content chart-group mt-1">
@@ -411,7 +419,12 @@
 								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("leader", label)'
 							>
-								<span class="transition-color transition-border-color">{{ $t('stats.charts.leader.title.' + label) }}</span>
+								<span
+									class="transition-color transition-border-color"
+									:class='{ "border-bottom-accent2": label=="received", "border-bottom-accent1": label=="sent"}'
+								>
+									{{ $t('stats.charts.leader.title.' + label) }}
+								</span>
 							</li>
 						</ul>
 						<div class="tab-content mt-1">

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -277,7 +277,7 @@
 							/>
 						</div>
 					</div>
-					<div v-show='!preferences.sections.total.expand' class='chart-group position-relative'>
+					<div v-show='!preferences.sections.total.expand' class='tab-area position-relative'>
 						<div class='position-absolute top-0-5 right-0-5 d-flex gap-0-5'>
 							<div class='d-inline-flex align-center' :class='{"cursor-pointer": preferences.sections.days.year > minYear}' @click.prevent='previousYear()'>
 								<svg class='icon icon-bold icon-gray icon-hover-accent' :class='{"v-hidden": preferences.sections.days.year <= minYear}' viewBox='0 0 24 24'>
@@ -295,28 +295,39 @@
 								</svg>
 							</div>
 						</div>
-						<!-- activity per day received -->
-						<HeatMap
-							:title='$t("stats.charts.days.title", [preferences.sections.days.year])'
-							:description='$t("stats.charts.days.description.received")'
-							rgb='10, 132, 255'
-							spacing='1px'
-							rounding='5px'
-							:dataset='daysChartData.received'
-							:labels='{ y: daysChartData.ylabels, x: daysChartData.xlabels }'
-							:tooltips='"{y}, " + $t("stats.abbreviations.calendarWeek") + "{x}\n{label}: {value}"'
-							class='mb-0-5 upper-chart'
-						/>
-						<!-- activity per day sent -->
-						<HeatMap
-							:description='$t("stats.charts.days.description.sent")'
-							rgb='230, 77, 185'
-							spacing='1px'
-							rounding='5px'
-							:dataset='daysChartData.sent'
-							:labels='{ y: daysChartData.ylabels, x: daysChartData.xlabels }'
-							:tooltips='"{y}, " + $t("stats.abbreviations.calendarWeek") + "{x}\n{label}: {value}"'
-						/>
+						<ul class='tab'>
+							<li
+								v-for='(active, label) in tabs.activity'
+								:key='label'
+								class='tab-item cursor-pointer tooltip tooltip-bottom text-hover-accent2'
+								:data-tooltip='$t("stats.charts." + label + ".description")'
+								:class='{ "active": active }'
+								@click='activateTab("activity", label)'
+							>
+								<span>{{ $t('stats.charts.' + label + '.title', [preferences.sections.days.year]) }}</span>
+							</li>
+						</ul>
+						<div class='tab-content chart-group mt-1'>
+							<!-- activity per day received -->
+							<HeatMap
+								rgb='10, 132, 255'
+								spacing='1px'
+								rounding='5px'
+								:dataset='daysChartData.received'
+								:labels='{ y: daysChartData.ylabels, x: daysChartData.xlabels }'
+								:tooltips='"{y}, " + $t("stats.abbreviations.calendarWeek") + "{x}\n{label}: {value}"'
+								class='mt-2 mb-1-5'
+							/>
+							<!-- activity per day sent -->
+							<HeatMap
+								rgb='230, 77, 185'
+								spacing='1px'
+								rounding='5px'
+								:dataset='daysChartData.sent'
+								:labels='{ y: daysChartData.ylabels, x: daysChartData.xlabels }'
+								:tooltips='"{y}, " + $t("stats.abbreviations.calendarWeek") + "{x}\n{label}: {value}"'
+							/>
+						</div>
 					</div>
 				</div>
 				<div id='chart-area-main' class='chart-area mt-2'>
@@ -517,6 +528,9 @@ export default {
 					months: false,
 					weeks: false,
 				},
+				activity: {
+					days: true,
+				}
 			},
 			preferences: {   // preferences set for this page
 				sections: {    // preferences that can be set on this page
@@ -1610,7 +1624,7 @@ body
 				column-gap: 2rem
 				row-gap: 1rem
 				transition: grid-template-columns .2s
-				& > *, .tab-content > *
+				& > *, .tab-content:not(.chart-group) > *
 					min-height: 380px
 				.chart
 					min-width: 0
@@ -1618,7 +1632,5 @@ body
 						margin-bottom: 0
 					p
 						margin-top: 0
-				.chart-group .upper-chart h2
-					margin-top: .5rem
 
 </style>

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -139,6 +139,8 @@ for m, c in mode
 	font-weight: 300
 .mt-1
 	margin-top: 1rem
+.mt-1-5
+	margin-top: 1.5rem
 .mt-2
 	margin-top: 2rem
 .mt-3

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -84,6 +84,8 @@ for m, c in mode
 	transition: color transition.duration transition.function
 .transition-border-color
 	transition: border-color transition.duration transition.function
+.transition-border-image
+	transition: border-image transition.duration transition.function
 
 // coloring
 for m, c in mode
@@ -611,7 +613,12 @@ input[type=number]
 			border-bottom-color: c.gray3
 			color: c.gray1
 			.tab-item.active > span
-				border-bottom-color: c.accent2
+				&.border-bottom-accent2
+					border-bottom-color: c.accent2
+				&.border-bottom-accent1
+					border-bottom-color: c.accent1
+				&.border-bottom-gradient-accent2-accent1
+					  border-image: linear-gradient(to right, c.accent2, c.accent1) 100% 1
 				color: c.highlight
 
 // tags

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -82,6 +82,8 @@ for m, c in mode
 	transition: width transition.duration transition.function
 .transition-color
 	transition: color transition.duration transition.function
+.transition-border-color
+	transition: border-color transition.duration transition.function
 
 // coloring
 for m, c in mode
@@ -266,6 +268,8 @@ for m, c in mode
 	visibility: hidden
 
 // cursor
+.cursor-default
+	cursor: default
 .cursor-pointer
 	cursor: pointer
 .cursor-na
@@ -608,7 +612,7 @@ input[type=number]
 			color: c.gray1
 			.tab-item.active > span
 				border-bottom-color: c.accent2
-				color: c.accent2
+				color: c.highlight
 
 // tags
 .tag

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -94,6 +94,8 @@ export default {
 				this.chart.data.datasets.forEach((d, i) => {
 					if (i in this.currentData) {
 						d.data = this.currentData[i].data
+						d.backgroundColor = this.currentData[i].backgroundColor
+						d.borderColor = this.currentData[i].borderColor
 					} else {
 						this.chart.data.datasets.pop()
 					}
@@ -102,6 +104,8 @@ export default {
 				this.currentData.forEach((d, i) => {
 					if (i in this.chart.data.datasets) {
 						this.chart.data.datasets[i].data = d.data
+						this.chart.data.datasets[i].backgroundColor = d.backgroundColor
+						this.chart.data.datasets[i].borderColor = d.borderColor
 					} else {
 						this.chart.data.datasets.push(d)
 					}


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

- Create groups of similar charts
- Use tab navigation for every group, even if there is only one tab (because tabs serve as heading and their tooltip as description here)
- Active tab border color indicates which email class is displayed in the corresponding chart (received, sent or both)
- Increase the size of the last chart areas when viewport is ultrawide

## Benefits
Stats page is now more structured and a much less messy:

![thirdstats_new_stats_page_screenshot](https://user-images.githubusercontent.com/5441654/106349086-43c81000-62cb-11eb-9fe3-5d6a5088fb93.png)

## Applicable Issues

Closes #230
