### PR TITLE
Adjust responsiveness

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -1491,7 +1491,7 @@ export default {
 				datasets: [
 					{ label: this.$t('stats.mailsReceived'), data: Object.values(r), color: 'rgb(10, 132, 255)', bcolor: 'rgb(10, 132, 255, .2)' },
 				],
-				labels: Object.keys(r)
+				labels: new Array(25).fill('12345678901234567890123456789012345678901234567890')
 			}
 		},
 		// prepare data for sent emails leaderboard horizontal bar chart
@@ -1600,24 +1600,28 @@ body
 		padding-right: 1rem
 		box-sizing: border-box
 
-		@media (min-width: 2501px)
+		@media (max-width: 4320px)
 			max-width: 2500px
-			#chart-area-main
-				grid-template-columns: repeat(4, 1fr)
-		@media (max-width: 2500px)
-			max-width: 2200px
-			#chart-area-main
-				grid-template-columns: repeat(3, 1fr)
-		@media (max-width: 2000px)
-			max-width: 1750px
-			#chart-area-main
-				grid-template-columns: repeat(3, 1fr)
-		@media (min-width: 1501px)
 			header
 				grid-template-columns: 1fr 2fr
 				.filter
 					justify-content: flex-end
-		@media (max-width: 1500px)
+			.numbers
+				max-width: 1500px
+				grid-template-columns: repeat(6, 1fr)
+			#chart-area-top
+				grid-template-columns: calc(100% - 1130px - 2rem) 1130px
+				&.first-column-only
+					grid-template-columns: calc(100%-1rem) 0%
+				.resizer
+					display: list-item
+			#chart-area-main
+				grid-template-columns: calc(33.33% - 1rem) 550px auto
+		@media (max-width: 2500px)
+			max-width: 2200px
+		@media (max-width: 2000px)
+			max-width: 1750px
+		@media (max-width: 1750px)
 			max-width: 1200px
 			header
 				grid-template-columns: 1fr
@@ -1627,28 +1631,15 @@ body
 					justify-content: space-around
 					&>*
 						margin: 0 0 1rem 0
-			#chart-area-main
-				grid-template-columns: repeat(2, 1fr)
-		@media (min-width: 961px)
-			.numbers
-				max-width: 1500px
-				grid-template-columns: repeat(6, 1fr)
-			#chart-area-top
-				grid-template-columns: calc(33.33% - 1rem) calc(66.66% - 1rem)
-				&.first-column-only
-					grid-template-columns: calc(100%-1rem) 0%
-				.resizer
-					display: list-item
-		@media (max-width: 960px)
-			.numbers
-				grid-template-columns: repeat(3, 1fr)
 			#chart-area-top
 				grid-template-columns: calc(100%-1rem)
 				.resizer
 					display: none
-		@media (max-width: 720px)
 			#chart-area-main
-				grid-template-columns: 1fr
+				grid-template-columns: calc(100%-1rem)
+		@media (max-width: 960px)
+			.numbers
+				grid-template-columns: repeat(3, 1fr)
 
 		header
 			margin-top: 0

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -1491,7 +1491,7 @@ export default {
 				datasets: [
 					{ label: this.$t('stats.mailsReceived'), data: Object.values(r), color: 'rgb(10, 132, 255)', bcolor: 'rgb(10, 132, 255, .2)' },
 				],
-				labels: new Array(25).fill('12345678901234567890123456789012345678901234567890')
+				labels: Object.keys(r)
 			}
 		},
 		// prepare data for sent emails leaderboard horizontal bar chart


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Responsiveness is improved especially for large email addresses in the leader board section.

## Benefits

- Heatmaps keep their size from 1750px and wider viewports and sibling chart areas (like leader boards) adjust to the available space
- one column layout up to 1750px

## Applicable Issues

#232 
