### PR TITLE
Stats comparison

### DIFF
--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -25,7 +25,7 @@
     "mailsWeek": "E-Mails/Woche",
     "loadingInProgress": "E-Mails für dieses Konto werden geladen...",
     "accountEmpty": "Dieses Konto ist leer und enthält keine E-Mails.",
-    "allAccountsSum": "Alle Konten (Summe)",
+    "allAccounts": "Alle Konten",
     "dataCollected": "Daten vor {0} abgerufen",
     "timePeriod": "Zeitraum",
     "charts": {
@@ -138,7 +138,8 @@
     },
     "activeAccounts": {
       "label": "Aktive Konten",
-      "description": "Einzelne Konten aktivieren oder deaktivieren. Deaktivierte Konten werden nicht gelistet und von der Statistik ausgeschlossen."
+      "description": "Einzelne Konten aktivieren oder deaktivieren. Deaktivierte Konten werden nicht gelistet und von der Statistik ausgeschlossen.",
+      "color": "Jedem Konto kann eine benutzerdefinierte Farbe zugewiesen werden, um die Konten im Vergleichsmodus zu unterscheiden."
     },
     "selfMessages": {
       "label": "Eigennachrichten",
@@ -167,6 +168,11 @@
       "description": "Alle Statistikdaten aller Konten aus dem Cache löschen. Durch Öffnen der Statistikseite wird der Cache neu aufgebaut.",
       "empty": "Der Cache ist leer",
       "size": "Die Größe des Caches beträgt {0}"
+    },
+    "resetOptions": {
+      "label": "Einstellungen zurücksetzen",
+      "description": "Alle Einstellungen auf die Standardwerte zurücksetzen.",
+      "removeIdentities": "Dadurch werden auch alle lokalen Identitäten gelöscht."
     },
     "note": {
       "title": "Hinweis",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -25,7 +25,7 @@
     "mailsWeek": "mails/week",
     "loadingInProgress": "Loading of all emails from this account in progress...",
     "accountEmpty": "This account is empty, no emails here.",
-    "allAccountsSum": "All Accounts (Sum)",
+    "allAccounts": "All Accounts",
     "timePeriod": "Date range",
     "dataCollected": "Data collected {0} ago",
     "charts": {
@@ -140,7 +140,8 @@
     },
     "activeAccounts": {
       "label": "Active Accounts",
-      "description": "Enable or disable accounts. Disabled accounts won't appear in any accounts list or stats."
+      "description": "Enable or disable accounts. Disabled accounts won't appear in any accounts list or stats.",
+      "color": "Give each account a custom color to distinguish between them in comparison mode."
     },
     "selfMessages": {
       "label": "Self Messages",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -75,6 +75,8 @@
       }
     },
     "tooltips": {
+      "comparison": "Compare accounts in one chart",
+      "sum": "Show sum of all accounts",
       "expand": "Expand chart area",
       "shrink": "Shrink chart area",
       "refresh": "Refresh data",

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -99,10 +99,14 @@
 						<span class='d-block text-gray text-small'>{{ $t('options.activeAccounts.description') }}</span>
 					</label>
 					<div class='action'>
-						<div v-for='a in allAccounts' :key='a.id'>
-							<label class="checkbox">
+						<div v-for='(a, i) in allAccounts' :key='i' class="d-flex justify-space-between">
+							<label class="checkbox cursor-pointer text-overflow-ellipsis flex-dont-grow">
 								<input type='checkbox' :value='a.id' v-model='options.accounts' />
 								<i class="checkbox-icon"></i> {{ a.name }}
+							</label>
+							<label :for="'color-' + a.name" class="cursor-pointer d-flex align-items-center gap-0-5">
+								<input type='color' :id="'color-' + a.name" v-model='options.accountColors[a.id]' />
+								<span class="text-mono text-tiny">{{ options.accountColors[a.id] }}</span>
 							</label>
 						</div>
 					</div>
@@ -248,7 +252,17 @@ export default {
 	},
 	methods: {
 		// create options object with given values or default values
-		optionsObject (dark=true, ordinate=false, startOfWeek=0, addresses='', accounts=[], selfMessages='none', leaderCount=20, cache=true) {
+		optionsObject (
+			dark = true,
+			ordinate = false,
+			startOfWeek = 0,
+			addresses = '',
+			accounts = [],
+			accountColors = {},
+			selfMessages = 'none',
+			leaderCount = 20,
+			cache = true
+		) {
 			return {
 				options: {
 					dark: dark === null ? this.options.dark : dark,
@@ -256,6 +270,7 @@ export default {
 					startOfWeek: startOfWeek === null ? this.options.startOfWeek : startOfWeek,
 					addresses: addresses === null ? this.options.addresses : addresses,
 					accounts: accounts === null ? this.options.accounts : accounts,
+					accountColors: accountColors === null ? this.options.accountColors : accountColors,
 					selfMessages: selfMessages === null ? this.options.selfMessages : selfMessages,
 					leaderCount: leaderCount === null ? this.options.leaderCount : leaderCount,
 					cache: cache === null ? this.options.cache : cache,
@@ -288,6 +303,14 @@ export default {
 				}
 				// update accounts option
 				this.options.accounts = activeAccounts
+			}
+			// if some or all account colors are not initialized yet, initialize them
+			if (this.options && this.options.accountColors) {
+				this.allAccounts.map((a, i) => {
+					if (!this.options.accountColors.hasOwnProperty(a.id)) {
+						this.options.accountColors[a.id] = this.defaultColors[(i%this.defaultColors.length)]
+					}
+				})
 			}
 		},
 		// get size of all cached account data
@@ -365,6 +388,11 @@ export default {
 		addressList () {
 			return this.options && this.options.addresses ? this.options.addresses.split(',') : []
 		},
+		// array of default colors to be used for accounts
+		defaultColors () {
+			return ['#f9844a', '#f9c74f', '#90be6d', '#43aa8b', '#4d908e', '#577590', '#9c89b8']
+		},
+		// return all valid option values for selfMessages
 		selfMessagesOptions () {
 			return [
 				'none',
@@ -425,7 +453,7 @@ html, body
 				font-weight: 300
 			.entry
 				display: grid
-				grid-template-columns: 1fr 1fr
+				grid-template-columns: 1fr 50%
 				column-gap: 2rem
 				margin-bottom: 1rem
 				.action

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -96,7 +96,10 @@
 				<div class='entry' v-if="options.accounts">
 					<label>
 						{{ $t('options.activeAccounts.label') }}
-						<span class='d-block text-gray text-small'>{{ $t('options.activeAccounts.description') }}</span>
+						<span class='d-block text-gray text-small'>
+							{{ $t('options.activeAccounts.description') }}
+							{{ $t('options.activeAccounts.color') }}
+						</span>
 					</label>
 					<div class='action'>
 						<div v-for='(a, i) in allAccounts' :key='i' class="d-flex justify-space-between">

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -228,7 +228,9 @@
 </template>
 
 <script>
+import { defaultColors } from './definitions'
 import { formatBytes } from './utils'
+
 export default {
 	name: 'Options',
 	data () {
@@ -308,7 +310,7 @@ export default {
 			if (this.options && this.options.accountColors) {
 				this.allAccounts.map((a, i) => {
 					if (!this.options.accountColors.hasOwnProperty(a.id)) {
-						this.options.accountColors[a.id] = this.defaultColors[(i%this.defaultColors.length)]
+						this.options.accountColors[a.id] = defaultColors[(i%defaultColors.length)]
 					}
 				})
 			}
@@ -387,10 +389,6 @@ export default {
 		// array of email addresses configured for local account identities
 		addressList () {
 			return this.options && this.options.addresses ? this.options.addresses.split(',') : []
-		},
-		// array of default colors to be used for accounts
-		defaultColors () {
-			return ['#f9844a', '#f9c74f', '#90be6d', '#43aa8b', '#4d908e', '#577590', '#9c89b8']
 		},
 		// return all valid option values for selfMessages
 		selfMessagesOptions () {

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -219,6 +219,7 @@
 								</span>
 							</li>
 							<li
+								v-if="active.account == 'sum'"
 								class='resizer cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto'
 								:data-tooltip='
 									!preferences.sections.total.comparison
@@ -237,6 +238,7 @@
 							</li>
 							<li
 								class='resizer cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1'
+								:class="{ 'ml-auto': active.account != 'sum' }"
 								:data-tooltip='
 									!preferences.sections.total.expand
 									? $t("stats.tooltips.expand")
@@ -263,7 +265,7 @@
 						<div class='tab-content mt-1'>
 							<!-- emails per year over total time -->
 							<LineChart
-								v-if='tabs.total.years'
+								v-if='tabs.total.years && !preferences.sections.total.comparison'
 								:datasets='yearsChartData.datasets'
 								:labels='yearsChartData.labels'
 								:ordinate='preferences.ordinate'
@@ -271,7 +273,7 @@
 							/>
 							<!-- emails per quarter over total time -->
 							<LineChart
-								v-if='tabs.total.quarters'
+								v-if='tabs.total.quarters && !preferences.sections.total.comparison'
 								:datasets='quartersChartData.datasets'
 								:labels='quartersChartData.labels'
 								:ordinate='preferences.ordinate'
@@ -279,7 +281,7 @@
 							/>
 							<!-- emails per month over total time -->
 							<LineChart
-								v-if='tabs.total.months'
+								v-if='tabs.total.months && !preferences.sections.total.comparison'
 								:datasets='monthsChartData.datasets'
 								:labels='monthsChartData.labels'
 								:ordinate='preferences.ordinate'
@@ -287,7 +289,7 @@
 							/>
 							<!-- emails per week over total time -->
 							<LineChart
-								v-if='tabs.total.weeks'
+								v-if='tabs.total.weeks && !preferences.sections.total.comparison'
 								:datasets='weeksChartData.datasets'
 								:labels='weeksChartData.labels'
 								:ordinate='preferences.ordinate'
@@ -1576,6 +1578,8 @@ export default {
 		// and load new accounts data accordingly
 		async 'active.account' (id) {
 			if (id) {
+				// reset preferences
+				this.preferences.sections.total.comparison = false
 				// reset filter
 				this.resetFolder(false)
 				// process data for given account, refresh if period filter is set

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -573,6 +573,7 @@
 
 <script>
 // internal components
+import { defaultColors } from './definitions';
 import { traverseAccount, extractEmailAddress, weekNumber, weeksInYear, quarterNumber, hexToRgb } from './utils';
 import LineChart from './charts/LineChart'
 import BarChart from './charts/BarChart'
@@ -834,6 +835,12 @@ export default {
 		// get active account from URL get parameter
 		async getAccounts () {
 			let accounts = await messenger.accounts.list()
+			// if account colors are not initialized yet, initialize them
+			if (Object.keys(this.preferences.accountColors).length == 0) {
+				accounts.map((a, i) => {
+					this.preferences.accountColors[a.id] = defaultColors[(i%defaultColors.length)]
+				})
+			}
 			if (this.preferences.accounts.length > 0) {
 				// filter list of accounts if user configured custom list
 				accounts = accounts.filter(a => this.preferences.accounts.includes(a.id))
@@ -1154,7 +1161,6 @@ export default {
 
 				// retrieve all values of account objects for comparison views
 				let comparison = JSON.parse(JSON.stringify(this.initComparisonData()))
-				console.log(accountsData)
 				accounts.map((a, i) => {
 					// years
 					comparison.yearsData[a.id] = sumObjects([accountsData[i].yearsData.received, accountsData[i].yearsData.sent])
@@ -1172,7 +1178,6 @@ export default {
 					comparison.monthData[a.id] = sumObjects([accountsData[i].monthData.received, accountsData[i].monthData.sent])
 				})
 				this.comparison = comparison
-				console.log(comparison)
 
 				// finally adjust displayed activity year
 				this.adjustSelectedYear()

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -22,7 +22,7 @@
 					<div class='filter-account d-flex'>
 						<label for='account' class='align-center text-gray p-0-5'>{{ $tc('popup.account', 1) }}</label>
 						<select v-model='active.account' :disabled='loading' class='align-stretch w-6' :class='{ disabled: loading }' id='account'>
-							<option v-if='accounts.length > 1 && preferences.cache' :value='"sum"'>{{ $t('stats.allAccountsSum') }}</option>
+							<option v-if='accounts.length > 1 && preferences.cache' :value='"sum"'>{{ $t('stats.allAccounts') }}</option>
 							<option v-for='a in accounts' :key='a.id' :value='a.id'>{{ a.name }}</option>
 						</select>
 						<div v-show='loading' :class='scheme + " loading align-center loader-accent2"'></div>
@@ -49,7 +49,7 @@
 						<div
 							class="d-flex align-stretch tooltip-bottom"
 							:class='{ tooltip: !singleAccount }'
-							:data-tooltip='$t("stats.tooltips.folder.notAvailable", [$t("stats.allAccountsSum")])'
+							:data-tooltip='$t("stats.tooltips.folder.notAvailable", [$t("stats.allAccounts")])'
 						>
 							<select
 								id='folder'
@@ -1068,7 +1068,7 @@ export default {
 			// check id type
 			if (!this.singleAccount && this.preferences.cache) {
 				// set tab title
-				document.title = 'ThirdStats: ' + this.$t('stats.allAccountsSum')
+				document.title = 'ThirdStats: ' + this.$t('stats.allAccounts')
 				// deactivate list of folders
 				this.folders = []
 				// iterate over all activated accounts

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -204,6 +204,7 @@
 					class='chart-area'
 					:class='{ "first-column-only": preferences.sections.total.expand }'
 				>
+					<!-- section: total -->
 					<div class='tab-area'>
 						<ul class='tab'>
 							<li
@@ -223,7 +224,7 @@
 							</li>
 							<li
 								v-if="active.account == 'sum'"
-								class='resizer cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto'
+								class='cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto'
 								:data-tooltip='
 									!preferences.sections.total.comparison
 									? $t("stats.tooltips.comparison")
@@ -328,6 +329,7 @@
 							/>
 						</div>
 					</div>
+					<!-- section: activity -->
 					<div v-show='!preferences.sections.total.expand' class='tab-area position-relative'>
 						<div class='position-absolute top-0-5 right-0-5 d-flex gap-0-5'>
 							<div class='d-inline-flex align-center' :class='{"cursor-pointer": preferences.sections.activity.year > minYear}' @click.prevent='previousYear()'>
@@ -384,6 +386,7 @@
 					</div>
 				</div>
 				<div id='chart-area-main' class='chart-area mt-2'>
+					<!-- section: onedim -->
 					<div class='tab-area'>
 						<ul class='tab'>
 							<li
@@ -394,35 +397,75 @@
 								:class='{ "active": active, "cursor-pointer": !active, "text-hover-accent2": !active }'
 								@click='activateTab("onedim", label)'
 							>
-								<span class="transition-color transition-border-image border-bottom-gradient-accent2-accent1">
+								<span
+									class="transition-color transition-border-image border-bottom-gradient-accent2-accent1"
+									:style="active && preferences.sections.onedim.comparison ? 'border-image: linear-gradient(to right, ' + accountsColorGradient + ') 100% 1' : ''"
+								>
 									{{ $t('stats.charts.' + label + '.title') }}
 								</span>
+							</li>
+							<li
+								v-if="active.account == 'sum'"
+								class='cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto'
+								:data-tooltip='
+									!preferences.sections.onedim.comparison
+									? $t("stats.tooltips.comparison")
+									: $t("stats.tooltips.sum")
+								'
+								@click='preferences.sections.onedim.comparison=!preferences.sections.onedim.comparison'
+							>
+								<svg class='icon icon-text icon-hover-accent' :class='{"icon-accent2": preferences.sections.onedim.comparison}' viewBox='0 0 24 24'>
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<rect class="icon-part-accent2" x="3" y="3" width="6" height="6" rx="1" />
+									<rect class="icon-part-accent1" x="15" y="15" width="6" height="6" rx="1" />
+									<path class="icon-part-accent2-faded" d="M21 11v-3a2 2 0 0 0 -2 -2h-6l3 3m0 -6l-3 3" />
+									<path class="icon-part-accent1-faded" d="M3 13v3a2 2 0 0 0 2 2h6l-3 -3m0 6l3 -3" />
+								</svg>
 							</li>
 						</ul>
 						<div class='tab-content mt-1'>
 							<!-- emails per time of day -->
 							<BarChart
-								v-if='tabs.onedim.daytime'
+								v-if='tabs.onedim.daytime && !preferences.sections.onedim.comparison'
 								:datasets='daytimeChartData.datasets'
 								:labels='daytimeChartData.labels'
 								:ordinate='preferences.ordinate'
 							/>
+							<BarChart
+								v-if='tabs.onedim.daytime && preferences.sections.onedim.comparison'
+								:datasets='daytimeComparedChartData.datasets'
+								:labels='daytimeComparedChartData.labels'
+								:ordinate='preferences.ordinate'
+							/>
 							<!-- emails per day of week -->
 							<BarChart
-								v-if='tabs.onedim.weekday'
+								v-if='tabs.onedim.weekday && !preferences.sections.onedim.comparison'
 								:datasets='weekdayChartData.datasets'
 								:labels='weekdayChartData.labels'
 								:ordinate='preferences.ordinate'
 							/>
+							<BarChart
+								v-if='tabs.onedim.weekday && preferences.sections.onedim.comparison'
+								:datasets='weekdayComparedChartData.datasets'
+								:labels='weekdayComparedChartData.labels'
+								:ordinate='preferences.ordinate'
+							/>
 							<!-- emails per month of year -->
 							<BarChart
-								v-if='tabs.onedim.month'
+								v-if='tabs.onedim.month && !preferences.sections.onedim.comparison'
 								:datasets='monthChartData.datasets'
 								:labels='monthChartData.labels'
 								:ordinate='preferences.ordinate'
 							/>
+							<BarChart
+								v-if='tabs.onedim.month && preferences.sections.onedim.comparison'
+								:datasets='monthComparedChartData.datasets'
+								:labels='monthComparedChartData.labels'
+								:ordinate='preferences.ordinate'
+							/>
 						</div>
 					</div>
+					<!-- section: twodim -->
 					<div class='tab-area'>
 						<ul class='tab'>
 							<li
@@ -460,6 +503,7 @@
 							/>
 						</div>
 					</div>
+					<!-- section: leader -->
 					<div class='tab-area'>
 						<ul class='tab'>
 							<li
@@ -670,6 +714,9 @@ export default {
 					activity: {
 						year: (new Date()).getFullYear()
 					},
+					onedim: {
+						comparison: false
+					}
 				},
 				dark: true,    // preferences loaded from stored options
 				ordinate: false,
@@ -1117,12 +1164,12 @@ export default {
 					comparison.monthsData[a.id] = sumObjectsObjects([accountsData[i].monthsData.received, accountsData[i].monthsData.sent])
 					// weeks
 					comparison.weeksData[a.id] = sumObjectsObjects([accountsData[i].weeksData.received, accountsData[i].weeksData.sent])
-					// // daytime
-					// comparison.daytimeData[a.id] = sumObjects([accountsData[i].daytimeData.received, accountsData[i].daytimeData.sent])
-					// // weekday
-					// comparison.weekdayData[a.id] = sumObjects([accountsData[i].weekdayData.received, accountsData[i].weekdayData.sent])
-					// // month
-					// comparison.monthData[a.id] = sumObjects([accountsData[i].monthData.received, accountsData[i].monthData.sent])
+					// daytime
+					comparison.daytimeData[a.id] = sumObjects([accountsData[i].daytimeData.received, accountsData[i].daytimeData.sent])
+					// weekday
+					comparison.weekdayData[a.id] = sumObjects([accountsData[i].weekdayData.received, accountsData[i].weekdayData.sent])
+					// month
+					comparison.monthData[a.id] = sumObjects([accountsData[i].monthData.received, accountsData[i].monthData.sent])
 				})
 				this.comparison = comparison
 				console.log(comparison)
@@ -1626,6 +1673,25 @@ export default {
 				labels: Object.keys(r)
 			}
 		},
+		// prepare comparison data for daytime bar chart
+		daytimeComparedChartData () {
+			let datasets = []
+			// compute dataset for each account
+			this.accounts.map((a) => {
+				const d = this.comparison.daytimeData[a.id]
+				// add dataset for this account
+				datasets.push({
+					label: this.$t('stats.mailsTotal') + ', ' + a.name,
+					data: Object.values(d),
+					color: this.preferences.accountColors[a.id],
+					bcolor: 'rgb(' + hexToRgb(this.preferences.accountColors[a.id]) + ', .2)'
+				})
+			})
+			return {
+				datasets: datasets,
+				labels: Object.keys(Object.values(this.comparison.daytimeData)[0])
+			}
+		},
 		// prepare data for weekday bar chart
 		weekdayChartData () {
 			let r = Object.values(this.display.weekdayData.received)
@@ -1645,6 +1711,32 @@ export default {
 				labels: labels
 			}
 		},
+		// prepare comparison data for weekday bar chart
+		weekdayComparedChartData () {
+			let datasets = []
+			let labels = [...this.weekdayNames]
+			// labels: start week with user defined day of week
+			for (let d = 0; d < this.preferences.startOfWeek; d++)
+				labels.push(labels.shift())
+			// compute dataset for each account
+			this.accounts.map((a) => {
+				const data = Object.values(this.comparison.weekdayData[a.id])
+				// data: start week with user defined day of week
+				for (let d = 0; d < this.preferences.startOfWeek; d++)
+					data.push(data.shift())
+				// add dataset for this account
+				datasets.push({
+					label: this.$t('stats.mailsTotal') + ', ' + a.name,
+					data: data,
+					color: this.preferences.accountColors[a.id],
+					bcolor: 'rgb(' + hexToRgb(this.preferences.accountColors[a.id]) + ', .2)'
+				})
+			})
+			return {
+				datasets: datasets,
+				labels: labels
+			}
+		},
 		// prepare data for month bar chart
 		monthChartData () {
 			let r = this.display.monthData.received, s = this.display.monthData.sent
@@ -1653,6 +1745,24 @@ export default {
 					{ label: this.$t('stats.mailsSent'), data: Object.values(s), color: 'rgb(230, 77, 185)', bcolor: 'rgb(230, 77, 185, .2)' },
 					{ label: this.$t('stats.mailsReceived'), data: Object.values(r), color: 'rgb(10, 132, 255)', bcolor: 'rgb(10, 132, 255, .2)' },
 				],
+				labels: this.monthNames
+			}
+		},
+		// prepare comparison data for month bar chart
+		monthComparedChartData () {
+			let datasets = []
+			// compute dataset for each account
+			this.accounts.map((a) => {
+				// add dataset for this account
+				datasets.push({
+					label: this.$t('stats.mailsTotal') + ', ' + a.name,
+					data: Object.values(this.comparison.monthData[a.id]),
+					color: this.preferences.accountColors[a.id],
+					bcolor: 'rgb(' + hexToRgb(this.preferences.accountColors[a.id]) + ', .2)'
+				})
+			})
+			return {
+				datasets: datasets,
 				labels: this.monthNames
 			}
 		},

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -221,13 +221,30 @@
 							<li
 								class='resizer cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto'
 								:data-tooltip='
+									!preferences.sections.total.comparison
+									? $t("stats.tooltips.comparison")
+									: $t("stats.tooltips.sum")
+								'
+								@click='preferences.sections.total.comparison=!preferences.sections.total.comparison'
+							>
+								<svg class='icon icon-text icon-hover-accent' :class='{"icon-accent2": preferences.sections.total.comparison}' viewBox='0 0 24 24'>
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<rect class="icon-part-accent2" x="3" y="3" width="6" height="6" rx="1" />
+									<rect class="icon-part-accent1" x="15" y="15" width="6" height="6" rx="1" />
+									<path class="icon-part-accent2-faded" d="M21 11v-3a2 2 0 0 0 -2 -2h-6l3 3m0 -6l-3 3" />
+									<path class="icon-part-accent1-faded" d="M3 13v3a2 2 0 0 0 2 2h6l-3 -3m0 6l3 -3" />
+								</svg>
+							</li>
+							<li
+								class='resizer cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1'
+								:data-tooltip='
 									!preferences.sections.total.expand
 									? $t("stats.tooltips.expand")
 									: $t("stats.tooltips.shrink")
 								'
 								@click='preferences.sections.total.expand=!preferences.sections.total.expand'
 							>
-								<svg v-show='!preferences.sections.total.expand' class='icon icon-text icon-arrows-maximize' viewBox='0 0 24 24'>
+								<svg v-show='!preferences.sections.total.expand' class='icon icon-text' viewBox='0 0 24 24'>
 									<path stroke='none' d='M0 0h24v24H0z' fill='none'/>
 									<polyline points='16 4 20 4 20 8' /><line x1='14' y1='10' x2='20' y2='4' />
 									<polyline points='8 20 4 20 4 16' /><line x1='4' y1='20' x2='10' y2='14' />
@@ -602,7 +619,8 @@ export default {
 			preferences: {   // preferences set for this page
 				sections: {    // preferences that can be set on this page
 					total: {
-						expand: false
+						expand: false,
+						comparison: false
 					},
 					activity: {
 						year: (new Date()).getFullYear()

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -280,17 +280,17 @@
 					</div>
 					<div v-show='!preferences.sections.total.expand' class='tab-area position-relative'>
 						<div class='position-absolute top-0-5 right-0-5 d-flex gap-0-5'>
-							<div class='d-inline-flex align-center' :class='{"cursor-pointer": preferences.sections.days.year > minYear}' @click.prevent='previousYear()'>
-								<svg class='icon icon-bold icon-gray icon-hover-accent' :class='{"v-hidden": preferences.sections.days.year <= minYear}' viewBox='0 0 24 24'>
+							<div class='d-inline-flex align-center' :class='{"cursor-pointer": preferences.sections.activity.year > minYear}' @click.prevent='previousYear()'>
+								<svg class='icon icon-bold icon-gray icon-hover-accent' :class='{"v-hidden": preferences.sections.activity.year <= minYear}' viewBox='0 0 24 24'>
 									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
 									<polyline class='icon-part-accent2' points="15 6 9 12 15 18" />
 								</svg>
 							</div>
-							<select v-model='preferences.sections.days.year' name='year'>
+							<select v-model='preferences.sections.activity.year' name='year'>
 								<option v-for='y in yearsList' :key='y' :value='y'>{{ y }}</option>
 							</select>
-							<div class='d-inline-flex align-center' :class='{"cursor-pointer": preferences.sections.days.year < maxYear}' @click.prevent='nextYear()'>
-								<svg class='icon icon-bold icon-gray icon-hover-accent' :class='{"v-hidden": preferences.sections.days.year >= maxYear}' viewBox='0 0 24 24'>
+							<div class='d-inline-flex align-center' :class='{"cursor-pointer": preferences.sections.activity.year < maxYear}' @click.prevent='nextYear()'>
+								<svg class='icon icon-bold icon-gray icon-hover-accent' :class='{"v-hidden": preferences.sections.activity.year >= maxYear}' viewBox='0 0 24 24'>
 									<path stroke='none' d='M0 0h24v24H0z' fill='none'/>
 									<polyline class='icon-part-accent2' points='9 6 15 12 9 18' />
 								</svg>
@@ -306,7 +306,7 @@
 								@click='activateTab("activity", label)'
 							>
 								<span class="transition-color transition-border-image border-bottom-gradient-accent2-accent1">
-									{{ $t('stats.charts.' + label + '.title', [preferences.sections.days.year]) }}
+									{{ $t('stats.charts.' + label + '.title', [preferences.sections.activity.year]) }}
 								</span>
 							</li>
 						</ul>
@@ -604,7 +604,7 @@ export default {
 					total: {
 						expand: false
 					},
-					days: {
+					activity: {
 						year: (new Date()).getFullYear()
 					},
 				},
@@ -1172,22 +1172,22 @@ export default {
 		adjustSelectedYear () {
 			const min = new Date(this.display.numbers.start).getFullYear()
 			const max = new Date(this.display.numbers.end).getFullYear()
-			const current = this.preferences.sections.days.year
-			if (current < min) this.preferences.sections.days.year = min
-			if (current > max) this.preferences.sections.days.year = max
+			const current = this.preferences.sections.activity.year
+			if (current < min) this.preferences.sections.activity.year = min
+			if (current > max) this.preferences.sections.activity.year = max
 		},
 		// increments selected year
 		// only up to the max existing year
 		nextYear () {
-			if (this.preferences.sections.days.year < this.maxYear) {
-				this.preferences.sections.days.year++
+			if (this.preferences.sections.activity.year < this.maxYear) {
+				this.preferences.sections.activity.year++
 			}
 		},
 		// decrements selected year
 		// only down to the min existing year
 		previousYear () {
-			if (this.preferences.sections.days.year > this.minYear) {
-				this.preferences.sections.days.year--
+			if (this.preferences.sections.activity.year > this.minYear) {
+				this.preferences.sections.activity.year--
 			}
 		},
 		// make given date <d> human readable
@@ -1448,11 +1448,11 @@ export default {
 		},
 		// prepare data for activity heatmaps
 		daysChartData () {
-			let r = this.preferences.sections.days.year in this.display.daysData.received
-				? Object.values(this.display.daysData.received[this.preferences.sections.days.year])
+			let r = this.preferences.sections.activity.year in this.display.daysData.received
+				? Object.values(this.display.daysData.received[this.preferences.sections.activity.year])
 				: Object.values(new NumberedObject(7,53))
-			let s = this.preferences.sections.days.year in this.display.daysData.sent
-				? Object.values(this.display.daysData.sent[this.preferences.sections.days.year])
+			let s = this.preferences.sections.activity.year in this.display.daysData.sent
+				? Object.values(this.display.daysData.sent[this.preferences.sections.activity.year])
 				: Object.values(new NumberedObject(7,53))
 			let ylabels = [...this.weekdayNames]
 			let xlabels = Array.from(Array(54).keys())

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -315,6 +315,8 @@ for m, c in mode
 				color: c.icon
 			&.icon-gray
 				stroke: c.gray2
+			&.icon-accent2
+				stroke: c.accent2
 			&.icon-hover-accent > *
 				transition: inherit
 			&.icon-hover-accent:hover

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -646,7 +646,7 @@ input[type=color]
 				&.border-bottom-accent1
 					border-bottom-color: c.accent1
 				&.border-bottom-gradient-accent2-accent1
-					  border-image: linear-gradient(to right, c.accent2, c.accent1) 100% 1
+					border-image: linear-gradient(to right, c.accent2, c.accent1) 100% 1
 				color: c.highlight
 
 // tags

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -38,7 +38,7 @@ transition = {
 
 // general
 :root
-	font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'
 	font-weight: 300
 	font-size: 16px
 html, body
@@ -125,6 +125,15 @@ for m, c in mode
 			background: c.accent2
 		.background-hover-accent2:hover
 			background: c.accent2 !important
+
+// text
+.text-mono
+	font-family: Menlo, Monaco, 'Courier New', monospace
+.text-overflow-ellipsis
+	display: inline-block
+	overflow: hidden
+	text-overflow: ellipsis
+	white-space: nowrap
 
 // positioning and size
 .text-center
@@ -234,6 +243,8 @@ for m, c in mode
 	flex-direction: column
 .flex-grow
 	flex-grow: 1
+.flex-dont-grow
+	flex-grow: 0
 .flex-wrap
 	flex-wrap: wrap
 .justify-space-between
@@ -426,6 +437,21 @@ textarea
 	font-size: .9rem
 input[type=number]
 	-moz-appearance: textfield
+input[type=color]
+	appearance: none
+	border: none
+	background: transparent
+	padding: 0
+	width: 1.5rem
+	height: 1.5rem
+	&::-moz-color-swatch
+		border-radius: 50%
+		border: none
+	for m, c in mode
+		.{m} &:hover::-moz-color-swatch,
+		.{m} &:active::-moz-color-swatch,
+		.{m} &:focus::-moz-color-swatch
+			box-shadow: 0 0 0 .25rem rgba(c.gray1, .2)
 
 .checkbox
 	display: block

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -87,29 +87,26 @@ export default {
 		},
 	},
 	watch: {
-		// update chart if data changes
+		// update chart if data changes in an animatable way
 		datasets () {
 			this.chart.data.labels = this.labels
-			if (this.chart.data.datasets.length >= this.currentData.length) {
-				this.chart.data.datasets.forEach((d, i) => {
-					if (i in this.currentData) {
-						d.data = this.currentData[i].data
-						d.label = this.currentData[i].label
-						d.backgroundColor = this.currentData[i].backgroundColor
-						d.borderColor = this.currentData[i].borderColor
-					} else {
-						this.chart.data.datasets.pop()
-					}
-				})
-			} else {
-				this.currentData.forEach((d, i) => {
-					if (i in this.chart.data.datasets) {
-						this.chart.data.datasets[i].data = d.data
-						this.chart.data.datasets[i].label = d.label
-						this.chart.data.datasets[i].backgroundColor = d.backgroundColor
-						this.chart.data.datasets[i].borderColor = d.borderColor
-					} else {
-						this.chart.data.datasets.push(d)
+			this.chart.data.datasets.map((chartDataset, i) => {
+				if (i in this.currentData) {
+					// update every existing dataset first
+					chartDataset.data = this.currentData[i].data
+					chartDataset.label = this.currentData[i].label
+					chartDataset.backgroundColor = this.currentData[i].backgroundColor
+					chartDataset.borderColor = this.currentData[i].borderColor
+				} else {
+					// remove no longer needed datasets
+					this.chart.data.datasets.splice(i)
+				}
+			})
+			if (this.chart.data.datasets.length < this.currentData.length) {
+				this.currentData.map((currentDataset, i) => {
+					if (!(i in this.chart.data.datasets)) {
+						// add new datasets
+						this.chart.data.datasets.push(currentDataset)
 					}
 				})
 			}

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -94,6 +94,7 @@ export default {
 				this.chart.data.datasets.forEach((d, i) => {
 					if (i in this.currentData) {
 						d.data = this.currentData[i].data
+						d.label = this.currentData[i].label
 						d.backgroundColor = this.currentData[i].backgroundColor
 						d.borderColor = this.currentData[i].borderColor
 					} else {
@@ -104,6 +105,7 @@ export default {
 				this.currentData.forEach((d, i) => {
 					if (i in this.chart.data.datasets) {
 						this.chart.data.datasets[i].data = d.data
+						this.chart.data.datasets[i].label = d.label
 						this.chart.data.datasets[i].backgroundColor = d.backgroundColor
 						this.chart.data.datasets[i].borderColor = d.borderColor
 					} else {

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -103,6 +103,7 @@ export default {
 				this.chart.data.datasets.forEach((d, i) => {
 					if (i in this.currentData) {
 						d.data = this.currentData[i].data
+						d.label = this.currentData[i].label
 						d.backgroundColor = this.currentData[i].backgroundColor
 						d.borderColor = this.currentData[i].borderColor
 					} else {
@@ -113,6 +114,7 @@ export default {
 				this.currentData.forEach((d, i) => {
 					if (i in this.chart.data.datasets) {
 						this.chart.data.datasets[i].data = d.data
+						this.chart.data.datasets[i].label = d.label
 						this.chart.data.datasets[i].backgroundColor = d.backgroundColor
 						this.chart.data.datasets[i].borderColor = d.borderColor
 					} else {

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -96,29 +96,26 @@ export default {
 		}
 	},
 	watch: {
-		// update chart if data changes
+		// update chart if data changes in an animatable way
 		datasets () {
 			this.chart.data.labels = this.labels
-			if (this.chart.data.datasets.length >= this.currentData.length) {
-				this.chart.data.datasets.forEach((d, i) => {
-					if (i in this.currentData) {
-						d.data = this.currentData[i].data
-						d.label = this.currentData[i].label
-						d.backgroundColor = this.currentData[i].backgroundColor
-						d.borderColor = this.currentData[i].borderColor
-					} else {
-						this.chart.data.datasets.pop()
-					}
-				})
-			} else {
-				this.currentData.forEach((d, i) => {
-					if (i in this.chart.data.datasets) {
-						this.chart.data.datasets[i].data = d.data
-						this.chart.data.datasets[i].label = d.label
-						this.chart.data.datasets[i].backgroundColor = d.backgroundColor
-						this.chart.data.datasets[i].borderColor = d.borderColor
-					} else {
-						this.chart.data.datasets.push(d)
+			this.chart.data.datasets.map((chartDataset, i) => {
+				if (i in this.currentData) {
+					// update every existing dataset first
+					chartDataset.data = this.currentData[i].data
+					chartDataset.label = this.currentData[i].label
+					chartDataset.backgroundColor = this.currentData[i].backgroundColor
+					chartDataset.borderColor = this.currentData[i].borderColor
+				} else {
+					// remove no longer needed datasets
+					this.chart.data.datasets.splice(i)
+				}
+			})
+			if (this.chart.data.datasets.length < this.currentData.length) {
+				this.currentData.map((currentDataset, i) => {
+					if (!(i in this.chart.data.datasets)) {
+						// add new datasets
+						this.chart.data.datasets.push(currentDataset)
 					}
 				})
 			}

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -103,6 +103,8 @@ export default {
 				this.chart.data.datasets.forEach((d, i) => {
 					if (i in this.currentData) {
 						d.data = this.currentData[i].data
+						d.backgroundColor = this.currentData[i].backgroundColor
+						d.borderColor = this.currentData[i].borderColor
 					} else {
 						this.chart.data.datasets.pop()
 					}
@@ -111,6 +113,8 @@ export default {
 				this.currentData.forEach((d, i) => {
 					if (i in this.chart.data.datasets) {
 						this.chart.data.datasets[i].data = d.data
+						this.chart.data.datasets[i].backgroundColor = d.backgroundColor
+						this.chart.data.datasets[i].borderColor = d.borderColor
 					} else {
 						this.chart.data.datasets.push(d)
 					}

--- a/src/definitions.js
+++ b/src/definitions.js
@@ -1,0 +1,5 @@
+const defaultColors = ['#f9844a', '#f9c74f', '#90be6d', '#43aa8b', '#4d908e', '#577590', '#9c89b8']
+
+export {
+	defaultColors
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,6 +53,14 @@ let formatBytes = (bytes, decimals=2) => {
 	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
 }
 
+// convert 6-digit hex to rgb string, e.g. '#ff0000' => '255,0,0'
+let hexToRgb = (hex) => {
+  var result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+  return result
+    ? parseInt(result[1], 16) + ',' + parseInt(result[2], 16) + ',' + parseInt(result[3], 16)
+    : null
+}
+
 // special pluralization rules
 let pluralizationPolish = (n) => {
 	if (n === 1) {
@@ -72,5 +80,6 @@ export {
 	weeksInYear,
 	quarterNumber,
 	formatBytes,
+	hexToRgb,
 	pluralizationPolish
 }


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This implements a comparison mode showing the total number of emails for each account. This mode was created for the years, quarters, months, weeks, daytime, weekday and month charts. To keep things simple and clean, I refrained from making a distinction between received and sent mails for each account in comparison mode - charts are always showing the total number of emails for the corresponding account.

![third-stats_comparison_mode](https://user-images.githubusercontent.com/5441654/107087603-f7655e80-67fb-11eb-82d1-15af9fbf8b96.gif)

In addition, the accounts option on the options page was extended to set a custom color for each account.

![image](https://user-images.githubusercontent.com/5441654/107087746-31cefb80-67fc-11eb-9349-f04466c84dd6.png)

## Benefits

Possibility to directly compare accounts. The date range filter works in comparison mode too.

## Applicable Issues

#152 
