### PR TITLE
Watch option changes

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -38,8 +38,8 @@
     "message": "-",
     "note": {
       "reloadStatsPage": "Options are automatically saved. Some option changes cannot be automatically applied to an already open stats page or to existing cache entries, if cache is activated. They are marked with corresponding icons.",
-      "reloadWindowRequired": "Stats window needs to be reloaded",
-      "refreshCacheRequired": "Cache needs to be rebuild",
+      "reloadWindowRequired": "If changed, stats window needs to be reloaded",
+      "refreshCacheRequired": "If changed, cache needs to be rebuild",
       "title": "Note"
     },
     "ordinate": {

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -37,7 +37,9 @@
     },
     "message": "-",
     "note": {
-      "reloadStatsPage": "Options are automatically saved. If the stats page is already open, you have to reopen or reload it for changes to be applied. For some options it's also necessary to refresh cached data if cache is enabled.",
+      "reloadStatsPage": "Options are automatically saved. Some option changes cannot be automatically applied to an already open stats page or to existing cache entries, if cache is activated. They are marked with corresponding icons.",
+      "reloadWindowRequired": "Stats window needs to be reloaded",
+      "refreshCacheRequired": "Cache needs to be rebuild",
       "title": "Note"
     },
     "ordinate": {
@@ -45,7 +47,7 @@
       "label": "Vertical Axis"
     },
     "resetOptions": {
-      "description": "Reset all options to their default values.",
+      "description": "Reset all options to their default values. Depending on which options youo changed before, a window or cache refresh may be required.",
       "label": "Reset Options",
       "removeIdentities": "This will also remove all local identities you created."
     },

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -7,6 +7,7 @@
 			"text-normal": true,
 			"background-normal": options.dark,
 			"background-highlight-contrast": !options.dark,
+			"embedded": !ownOptionsPage
 		}'
 	>
 		<header v-if='ownOptionsPage' class='pt-2 mx-auto'>
@@ -15,7 +16,7 @@
 				{{ $t('options.title') }}
 			</h1>
 		</header>
-		<div class='container p-1 mx-auto'>
+		<div class='container mx-auto'>
 			<!-- section related to ThirdStats appearance and UI -->
 			<section class='mb-3'>
 				<h2>{{ $t('options.headings.appearance') }}</h2>
@@ -66,8 +67,19 @@
 				<!-- option: addresses -->
 				<div class='entry'>
 					<label for='local'>
-						{{ $t('options.localIdentities.label') }}
-						<span class='d-block text-gray text-small'>{{ $t('options.localIdentities.description') }}</span>
+						<div class="d-flex align-items-end gap-0-5">
+							{{ $t('options.localIdentities.label') }}
+							<span class="tooltip text-gray mb--0-25" :data-tooltip="$t('options.note.refreshCacheRequired')">
+								<svg class="icon icon-tiny" viewBox="0 0 24 24">
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<path d="M12.983 8.978c3.955 -.182 7.017 -1.446 7.017 -2.978c0 -1.657 -3.582 -3 -8 -3c-1.661 0 -3.204 .19 -4.483 .515m-2.783 1.228c-.471 .382 -.734 .808 -.734 1.257c0 1.22 1.944 2.271 4.734 2.74" />
+									<path d="M4 6v6c0 1.657 3.582 3 8 3c.986 0 1.93 -.067 2.802 -.19m3.187 -.82c1.251 -.53 2.011 -1.228 2.011 -1.99v-6" />
+									<path d="M4 12v6c0 1.657 3.582 3 8 3c3.217 0 5.991 -.712 7.261 -1.74m.739 -3.26v-4" />
+									<line x1="3" y1="3" x2="21" y2="21" />
+								</svg>
+							</span>
+						</div>
+						<div class='text-gray text-small'>{{ $t('options.localIdentities.description') }}</div>
 					</label>
 					<div class='action'>
 						<div class="d-flex input-group">
@@ -95,11 +107,22 @@
 				<!-- option: account selection -->
 				<div class='entry' v-if="options.accounts">
 					<label>
-						{{ $t('options.activeAccounts.label') }}
-						<span class='d-block text-gray text-small'>
+						<div class="d-flex align-items-end gap-0-5">
+							{{ $t('options.activeAccounts.label') }}
+							<span class="tooltip text-gray mb--0-25" :data-tooltip="$t('options.note.reloadWindowRequired')">
+								<svg class="icon icon-tiny" viewBox="0 0 24 24">
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" />
+									<path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" />
+									<line x1="12" y1="9" x2="12" y2="12" />
+									<line x1="12" y1="15" x2="12.01" y2="15" />
+								</svg>
+							</span>
+						</div>
+						<div class='text-gray text-small'>
 							{{ $t('options.activeAccounts.description') }}
 							{{ $t('options.activeAccounts.color') }}
-						</span>
+						</div>
 					</label>
 					<div class='action'>
 						<div v-for='(a, i) in allAccounts' :key='i' class="d-flex justify-space-between">
@@ -117,8 +140,19 @@
 				<!-- option: selfMessages -->
 				<div class='entry'>
 					<label for='selfMessages'>
-						{{ $t('options.selfMessages.label') }}
-						<span class='d-block text-gray text-small'>{{ $t('options.selfMessages.description') }}</span>
+						<div class="d-flex align-items-end gap-0-5">
+							{{ $t('options.selfMessages.label') }}
+							<span class="tooltip text-gray mb--0-25" :data-tooltip="$t('options.note.refreshCacheRequired')">
+								<svg class="icon icon-tiny" viewBox="0 0 24 24">
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<path d="M12.983 8.978c3.955 -.182 7.017 -1.446 7.017 -2.978c0 -1.657 -3.582 -3 -8 -3c-1.661 0 -3.204 .19 -4.483 .515m-2.783 1.228c-.471 .382 -.734 .808 -.734 1.257c0 1.22 1.944 2.271 4.734 2.74" />
+									<path d="M4 6v6c0 1.657 3.582 3 8 3c.986 0 1.93 -.067 2.802 -.19m3.187 -.82c1.251 -.53 2.011 -1.228 2.011 -1.99v-6" />
+									<path d="M4 12v6c0 1.657 3.582 3 8 3c3.217 0 5.991 -.712 7.261 -1.74m.739 -3.26v-4" />
+									<line x1="3" y1="3" x2="21" y2="21" />
+								</svg>
+							</span>
+						</div>
+						<div class='text-gray text-small'>{{ $t('options.selfMessages.description') }}</div>
 					</label>
 					<div class='action d-flex flex-wrap'>
 						<select class='flex-grow mb-1' v-model='options.selfMessages' id='selfMessages'>
@@ -140,8 +174,19 @@
 				<!-- option: leaderCount -->
 				<div class='entry'>
 					<label for='leaderCount'>
-						{{ $t('options.leaderCount.label') }}
-						<span class='d-block text-gray text-small'>{{ $t('options.leaderCount.description') }}</span>
+						<div class="d-flex align-items-end gap-0-5">
+							{{ $t('options.leaderCount.label') }}
+							<span class="tooltip text-gray mb--0-25" :data-tooltip="$t('options.note.refreshCacheRequired')">
+								<svg class="icon icon-tiny" viewBox="0 0 24 24">
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<path d="M12.983 8.978c3.955 -.182 7.017 -1.446 7.017 -2.978c0 -1.657 -3.582 -3 -8 -3c-1.661 0 -3.204 .19 -4.483 .515m-2.783 1.228c-.471 .382 -.734 .808 -.734 1.257c0 1.22 1.944 2.271 4.734 2.74" />
+									<path d="M4 6v6c0 1.657 3.582 3 8 3c.986 0 1.93 -.067 2.802 -.19m3.187 -.82c1.251 -.53 2.011 -1.228 2.011 -1.99v-6" />
+									<path d="M4 12v6c0 1.657 3.582 3 8 3c3.217 0 5.991 -.712 7.261 -1.74m.739 -3.26v-4" />
+									<line x1="3" y1="3" x2="21" y2="21" />
+								</svg>
+							</span>
+						</div>
+						<div class='text-gray text-small'>{{ $t('options.leaderCount.description') }}</div>
 					</label>
 					<div class='action d-flex input-group'>
 						<input class='flex-grow' type='number' v-model='options.leaderCount' placeholder='20' min='1' max='999' id='leaderCount' />
@@ -202,8 +247,28 @@
 				<!-- action: reset options -->
 				<div class='entry'>
 					<label>
-						{{ $t('options.resetOptions.label') }}
-						<span class="d-block text-gray text-small">{{ $t('options.resetOptions.description') }}</span>
+						<div class="d-flex align-items-end gap-0-5">
+							{{ $t('options.resetOptions.label') }}
+							<span class="tooltip text-gray mb--0-25" :data-tooltip="$t('options.note.reloadWindowRequired')">
+								<svg class="icon icon-tiny" viewBox="0 0 24 24">
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" />
+									<path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" />
+									<line x1="12" y1="9" x2="12" y2="12" />
+									<line x1="12" y1="15" x2="12.01" y2="15" />
+								</svg>
+							</span>
+							<span class="tooltip text-gray mb--0-25" :data-tooltip="$t('options.note.refreshCacheRequired')">
+								<svg class="icon icon-tiny" viewBox="0 0 24 24">
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<path d="M12.983 8.978c3.955 -.182 7.017 -1.446 7.017 -2.978c0 -1.657 -3.582 -3 -8 -3c-1.661 0 -3.204 .19 -4.483 .515m-2.783 1.228c-.471 .382 -.734 .808 -.734 1.257c0 1.22 1.944 2.271 4.734 2.74" />
+									<path d="M4 6v6c0 1.657 3.582 3 8 3c.986 0 1.93 -.067 2.802 -.19m3.187 -.82c1.251 -.53 2.011 -1.228 2.011 -1.99v-6" />
+									<path d="M4 12v6c0 1.657 3.582 3 8 3c3.217 0 5.991 -.712 7.261 -1.74m.739 -3.26v-4" />
+									<line x1="3" y1="3" x2="21" y2="21" />
+								</svg>
+							</span>
+						</div>
+						<div class="text-gray text-small">{{ $t('options.resetOptions.description') }}</div>
 					</label>
 					<div class='action'>
 						<button @click='resetOptions' class='mb-1'>{{ $t('options.resetOptions.label') }}</button>
@@ -223,9 +288,31 @@
 			</section>
 		</div>
 		<hr class='mb-3' />
-		<footer class='p-1 mx-auto pb-3'>
+		<footer class='mx-auto pb-3'>
 			<h3 class='text-thin mb-0-5'>{{ $t('options.note.title') }}</h3>
-			<div class='text-gray text-small'>{{ $t('options.note.reloadStatsPage') }}</div>
+			<div class='text-gray text-small mb-0-5'>
+				{{ $t('options.note.reloadStatsPage') }}
+			</div>
+			<div class='d-flex align-items-center gap-0-5 mb-0-5 text-gray text-small'>
+				<svg class="icon icon-small" viewBox="0 0 24 24">
+					<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+					<path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" />
+					<path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" />
+					<line x1="12" y1="9" x2="12" y2="12" />
+					<line x1="12" y1="15" x2="12.01" y2="15" />
+				</svg>
+				{{ $t('options.note.reloadWindowRequired') }}
+			</div>
+			<div class='d-flex align-items-center gap-0-5 text-gray text-small'>
+				<svg class="icon icon-small" viewBox="0 0 24 24">
+					<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+					<path d="M12.983 8.978c3.955 -.182 7.017 -1.446 7.017 -2.978c0 -1.657 -3.582 -3 -8 -3c-1.661 0 -3.204 .19 -4.483 .515m-2.783 1.228c-.471 .382 -.734 .808 -.734 1.257c0 1.22 1.944 2.271 4.734 2.74" />
+					<path d="M4 6v6c0 1.657 3.582 3 8 3c.986 0 1.93 -.067 2.802 -.19m3.187 -.82c1.251 -.53 2.011 -1.228 2.011 -1.99v-6" />
+					<path d="M4 12v6c0 1.657 3.582 3 8 3c3.217 0 5.991 -.712 7.261 -1.74m.739 -3.26v-4" />
+					<line x1="3" y1="3" x2="21" y2="21" />
+				</svg>
+				{{ $t('options.note.refreshCacheRequired') }}
+			</div>
 		</footer>
 	</div>
 </template>
@@ -436,11 +523,19 @@ html, body
 	width: 100%
 	min-height: 100vh
 
-	header,
-	footer,
-	.container
-		width: 100%
+	header,	footer,	.container
+		width: calc(100% - 2rem)
 		max-width: 840px
+		padding: 1rem
+
+	&.embedded	
+		header,	footer,	.container
+			width: 100%
+			max-width: auto
+			padding-left: .5rem
+			padding-right: .5rem
+		.container > section:first-child > h2
+			margin-top: 0
 	
 	header
 		h1

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -786,7 +786,7 @@ export default {
 				if (JSON.stringify(n.accounts) != JSON.stringify(o.accounts)) this.preferences.accounts = n.accounts
 				if (JSON.stringify(n.accountColors) != JSON.stringify(o.accountColors)) this.preferences.accountColors = n.accountColors
 				if (n.selfMessages != o.selfMessages) this.preferences.selfMessages = n.selfMessages
-				if (n.leaderCount != o.leaderCount)  this.preferences.leaderCount = n.leaderCount
+				if (n.leaderCount != o.leaderCount) this.preferences.leaderCount = n.leaderCount
 				if (n.cache != o.cache) this.preferences.cache = n.cache
 			}
 		})

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -773,6 +773,23 @@ export default {
 		// initially reset displayed data
 		this.display = JSON.parse(JSON.stringify(this.initData()))
 		this.comparison = JSON.parse(JSON.stringify(this.initComparisonData()))
+		// watch for option changes
+		messenger.storage.onChanged.addListener((result, area) => {
+			if (area == "local" && result?.options?.newValue && result?.options?.oldValue) {
+				const n = result.options.newValue, o = result.options.oldValue
+				// only update, if options changed that can be directly applied
+				// and don't need a window refresh or data reprocessing
+				if (n.dark != o.dark) this.preferences.dark = n.dark
+				if (n.ordinate != o.ordinate) this.preferences.ordinate = n.ordinate
+				if (n.startOfWeek != o.startOfWeek) this.preferences.startOfWeek = n.startOfWeek
+				if (n.addresses != o.addresses) this.preferences.localIdentities = n.addresses.split(',').map(x => x.trim())
+				if (JSON.stringify(n.accounts) != JSON.stringify(o.accounts)) this.preferences.accounts = n.accounts
+				if (JSON.stringify(n.accountColors) != JSON.stringify(o.accountColors)) this.preferences.accountColors = n.accountColors
+				if (n.selfMessages != o.selfMessages) this.preferences.selfMessages = n.selfMessages
+				if (n.leaderCount != o.leaderCount)  this.preferences.leaderCount = n.leaderCount
+				if (n.cache != o.cache) this.preferences.cache = n.cache
+			}
+		})
 		// get stored options
 		await this.getOptions()
 		// retrieve all accounts
@@ -2041,11 +2058,11 @@ body
 					&>*
 						margin: 0 0 1rem 0
 			#chart-area-top
-				grid-template-columns: calc(100%-1rem)
+				grid-template-columns: calc(100% - 1rem)
 				.resizer
 					display: none
 			#chart-area-main
-				grid-template-columns: calc(100%-1rem)
+				grid-template-columns: calc(100% - 1rem)
 		@media (max-width: 960px)
 			.numbers
 				grid-template-columns: repeat(3, 1fr)

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -59,6 +59,7 @@ label
 hr
 	border: none
 	height: 1px
+	width: 50%
 	for m, c in mode
 		.{m} &
 			background: c.gray2
@@ -168,6 +169,8 @@ for m, c in mode
 	margin-left: 2rem
 .ml-auto
 	margin-left: auto
+.mb--0-25
+	margin-bottom: -.25rem
 .mb-0-5
 	margin-bottom: .5rem
 .mb-1
@@ -257,6 +260,8 @@ for m, c in mode
 	align-items: center
 .align-items-start
 	align-items: flex-start
+.align-items-end
+	align-items: flex-end
 .position-fixed
 	position: fixed
 .position-absolute
@@ -302,6 +307,10 @@ for m, c in mode
 	&.icon-text
 		width: 1rem
 		height: 1rem
+
+	&.icon-tiny
+		width: 1.25rem
+		height: 1.25rem
 
 	&.icon-small
 		width: 1.5rem

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -111,6 +111,11 @@ export default {
 				})
 			}
 			this.chart.update()
+		},
+		// update chart if ordinate display changes
+		ordinate (newValue) {
+			this.chart.options.scales.yAxes[0].display = this.horizontal || newValue
+			this.chart.update()
 		}
 	}
 }

--- a/src/charts/LineChart.vue
+++ b/src/charts/LineChart.vue
@@ -120,6 +120,11 @@ export default {
 				})
 			}
 			this.chart.update()
+		},
+		// update chart if ordinate display changes
+		ordinate (newValue) {
+			this.chart.options.scales.yAxes[0].display = newValue
+			this.chart.update()
 		}
 	}
 }


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change
Option changes are now being watched on the stats page and automatically updated, Changes of *Dark mode*, *Vertical axis*, *Start of Week* and the account colors are directly applied. All other options need a window or cache refresh. Options now have a hint symbol with a tooltip that indicates, wether the stats page or the cache has do be reloaded after changing the options value.

![image](https://user-images.githubusercontent.com/5441654/108262009-a68f2780-7164-11eb-8b93-3a603b09c162.png)

## Benefits

Being forced to refresh the stats page less often.

## Applicable Issues

#236
