### PR TITLE
Data export in JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,12 @@ ThirdStats does store the processed stats data in Thunderbirds extension storage
 
 **What exactly are all the permissions used for?**  
 ThirdStats needs 4 permissions to work (Thunderbird may not ask for all of them when installing this add-on):
+
 - `accountsRead`: To iterate over all messages in all folders of your Thunderbird accounts to count and process them
 - `messagesRead`: To read the message header and retrieve the following information from it: *author*, *bccList*, *ccList*, *date*, *read*, *recipients*
 - `tabs`: To open the stats page and the options page in a new tab
 - `storage`: To save processed data in Thunderbirds extension storage
+- `downloads`: To export processed stats data as JSON file
 
 **Does it run as a web server with an open port which would expose it to vulnerabilities?**  
 No. It only runs locally. You can check the [build files](https://third-stats.cdn.devmount.com/) yourself anytime by renaming `.xpi` to `.zip`, unzip it and browse the files

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -145,6 +145,7 @@
       }
     },
     "dataCollected": "Data collected {0} ago",
+    "exportData": "Export currently displayed data as JSON file",
     "loadingInProgress": "Loading of all emails from this account in progress...",
     "mailsPerDay": "Mails per day",
     "mailsPerMonth": "Mails per month",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -145,7 +145,6 @@
       }
     },
     "dataCollected": "Data collected {0} ago",
-    "exportData": "Export currently displayed data as JSON file",
     "loadingInProgress": "Loading of all emails from this account in progress...",
     "mailsPerDay": "Mails per day",
     "mailsPerMonth": "Mails per month",
@@ -173,6 +172,7 @@
         "empty": "Input is required"
       },
       "expand": "Expand chart area",
+      "exportData": "Export currently displayed data as JSON file",
       "folder": {
         "notAvailable": "Folders are not available for {0}"
       },

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -31,7 +31,8 @@
 		"accountsRead",
 		"messagesRead",
 		"tabs",
-		"storage"
+		"storage",
+		"downloads"
 	],
 	"icons": {
 		"64": "icon.svg",

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -114,7 +114,7 @@
 					<!-- data export -->
 					<div
 						class='cursor-pointer tooltip tooltip-bottom d-inline-flex align-center ml-2'
-						:data-tooltip='$t("stats.exportData")'
+						:data-tooltip='$t("stats.tooltips.exportData")'
 						@click="exportJson()"
 					>
 						<svg class='icon icon-bold icon-gray icon-hover-accent' viewBox="0 0 24 24">

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -111,9 +111,24 @@
 							</svg>
 						</div>
 					</div>
-					<!-- options launcher -->
+					<!-- data export -->
 					<div
 						class='cursor-pointer tooltip tooltip-bottom d-inline-flex align-center ml-2'
+						:data-tooltip='$t("stats.exportData")'
+						@click="exportJson()"
+					>
+						<svg class='icon icon-bold icon-gray icon-hover-accent' viewBox="0 0 24 24">
+							<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+							<path class='icon-part-accent2' d="M14 3v4a1 1 0 0 0 1 1h4" />
+							<path class='icon-part-accent2' d="M17 21h-10a2 2 0 0 1 -2 -2v-14a2 2 0 0 1 2 -2h7l5 5v11a2 2 0 0 1 -2 2z" />
+							<line class='icon-part-accent1' x1="9" y1="17" x2="9" y2="12" />
+							<line class='icon-part-accent1-faded' x1="12" y1="17" x2="12" y2="16" />
+							<line class='icon-part-accent1' x1="15" y1="17" x2="15" y2="14" />
+						</svg>
+					</div>
+					<!-- options launcher -->
+					<div
+						class='cursor-pointer tooltip tooltip-bottom d-inline-flex align-center ml-1'
 						:data-tooltip='$t("popup.openOptions")'
 						@click.prevent="openTab('options.html', '1')"
 					>
@@ -132,7 +147,7 @@
 					class='d-inline-block tooltip tooltip-bottom'
 					:data-tooltip='formatDate(display.meta.timestamp)'
 				>
-					<LiveAge :date="display.meta.timestamp" />
+					<LiveAge class="cursor-default" :date="display.meta.timestamp" />
 				</div>
 			</section>
 			<!-- fetured numbers -->
@@ -604,7 +619,7 @@
 <script>
 // internal components
 import { defaultColors } from './definitions';
-import { traverseAccount, extractEmailAddress, weekNumber, weeksInYear, quarterNumber, hexToRgb } from './utils';
+import { traverseAccount, extractEmailAddress, weekNumber, weeksInYear, quarterNumber, hexToRgb, yyyymmdd } from './utils';
 import LineChart from './charts/LineChart'
 import BarChart from './charts/BarChart'
 import HeatMap from './charts/HeatMap'
@@ -1419,6 +1434,16 @@ export default {
 		formatDate (d) {
 			let options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' }
 			return d ? (new Date(d)).toLocaleDateString(this.$i18n.locale, options) : ''
+		},
+		// export displayed data
+		// provides a JSON file for download
+		exportJson () {
+			const data = new Blob([JSON.stringify(this.display)], { type: "text/plain;charset=utf-8" })
+			messenger.downloads.download({
+				'url': URL.createObjectURL(data),
+				'filename': yyyymmdd(new Date()) + "_third-stats-export.json",
+				'saveAs': true
+			}).then(() => {}, () => {}) // TODO [alert]: Successfully started download | Download aborted
 		},
 		// open given url in new tab
 		// appends GET parameter

--- a/src/utils.js
+++ b/src/utils.js
@@ -43,6 +43,11 @@ let quarterNumber = (d) => {
 	return (Math.ceil(month / 3))
 }
 
+// function to format given date as YYYYMMDD
+let yyyymmdd = (d) => {
+	return d.toISOString().replace(/-/g, '').slice(0,8)
+}
+
 // function to format bytes and append unit
 let formatBytes = (bytes, decimals=2) => {
 	if (bytes === 0) return '0 Bytes'
@@ -79,6 +84,7 @@ export {
 	weekNumber,
 	weeksInYear,
 	quarterNumber,
+	yyyymmdd,
 	formatBytes,
 	hexToRgb,
 	pluralizationPolish


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Provides the possibility to export the currently displayed data in JSON format. The export button is next to the options button in the top right corner of the stats page. It's always an export of the currently displayed data, making it possible to adjust the export by using the filter fields (accounts, folders and date range).

This requires an additional permission `downloads`.

## Benefits

This gives users the opportunity to evaluate the data in other programs.
![image](https://user-images.githubusercontent.com/5441654/108354791-3fb45180-71ea-11eb-8277-916cf4e86889.png)

## Applicable Issues

#233 
