### PR TITLE
Revamp permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ Also keep in mind, that the processing of large mailboxes can take a lot of time
 
 Here is how ThirdStats looks like on the Thunderbird default dark theme and light theme on Windows:
 
-![thirdstats_screenshot_version_1 5 0](https://user-images.githubusercontent.com/5441654/108669856-1e9b7b80-74de-11eb-9f53-3b91962a9461.png)
+![thirdstats_screenshot_version_1.5.0](https://user-images.githubusercontent.com/5441654/108669856-1e9b7b80-74de-11eb-9f53-3b91962a9461.png)
 
 ## Privacy and Security
 
-TL;DR: ThirdStats is fully contained and doesn't contact any third-party CDN servers. It runs locally without any webserver. ThirdStats stores processed data in a cache, but you can clear and disable it. ThirdStats will never store this data elsewhere, nor sent or sell it anywhere. ThirdStats needs permissions to access accounts, read email headers, open tabs, use extension storage and download export files.
+ThirdStats is fully contained and doesn't contact any third-party CDN servers. It runs locally without any webserver. ThirdStats stores processed data in a cache, but you can clear and disable it. ThirdStats will never store this data elsewhere, nor sent or sell it anywhere. ThirdStats needs permissions to access accounts, read email headers and download export files.
 
 See the [Security Policy](./SECURITY.md) for details how ThirdStats values your privacy.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,7 @@
 
 ## Supported Versions
 
-These versions of ThirdStats are currently being supported with security updates:
-
-| Version | Supported |
-| ------- | --------- |
-| 1.5.x   | ✅        |
-| 1.4.x   | ❌        |
-| < 1.4   | ❌        |
+The last stable version of ThirdStats is always being supported with security updates.
 
 ## Reporting a Vulnerability
 
@@ -26,13 +20,11 @@ ThirdStats does store the processed stats data in Thunderbirds own extension sto
 
 ### 3. What exactly are all the permissions used for?
 
-ThirdStats needs 5 permissions to work (Thunderbird may not ask for all of them when installing this add-on):
+ThirdStats needs 3 permissions to work:
 
-- `accountsRead`: To iterate over all messages in all folders of your Thunderbird accounts to count and process them
-- `messagesRead`: To read the message header and retrieve the following information from it: *author*, *bccList*, *ccList*, *date*, *read*, *recipients*
-- `tabs`: To open the stats page and the options page in a new tab
-- `storage`: To save processed data in Thunderbirds extension storage
-- `downloads`: To export processed stats data as JSON file
+- `accountsRead`: _"See your mail accounts and their folders"_ - This is needed to iterate over all messages in all folders of your Thunderbird accounts to count and process them.
+- `messagesRead`: _"Read your email messages and mark or tag them"_ - This is needed to read the message header and retrieve the following information from it: *author*, *bccList*, *ccList*, *date*, *read*, *recipients*. ThirdStats never reads the email body or marks/tags emails.
+- `downloads`: _"Download files and read and modify the browser’s download history"_ - This is needed to export processed stats data as JSON file and provide it as a file download. ThirdStats never reads or modifies the download history.
 
 ### 4. Does it run as a web server with an open port which would expose it to vulnerabilities?
 

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -30,7 +30,6 @@
 	"permissions": [
 		"accountsRead",
 		"messagesRead",
-		"tabs",
 		"storage",
 		"downloads"
 	],

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -289,7 +289,7 @@
 		</div>
 		<hr class="mb-3" />
 		<footer class="mx-auto pb-3">
-			<h3 class="text-thin mb-0-5">{{ $t("options.note.title") }}</h3>
+			<label class="mb-0-5">{{ $t("options.note.title") }}</label>
 			<div class="text-gray text-small mb-0-5">
 				{{ $t("options.note.reloadStatsPage") }}
 			</div>


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Removes the `tabs` permission and updates permissions docs

## Benefits

One permission less, more transparency about permissions

## Applicable Issues

#268 
