### PR TITLE
🔨 fix folder stats order

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -2079,8 +2079,8 @@ export default {
 			})
 			return {
 				datasets: [
-					{ label: this.$t("stats.mailsSent"), data: ds, color: "rgb(" + hexToRgb(accentColors[0]) + ")" },
 					{ label: this.$t("stats.mailsReceived"), data: dr, color: "rgb(" + hexToRgb(accentColors[1]) + ")" },
+					{ label: this.$t("stats.mailsSent"), data: ds, color: "rgb(" + hexToRgb(accentColors[0]) + ")" },
 				],
 				labels: labels
 			}


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

The order of received and sent folder stats got mistakenly reversed in the latest refactoring change.

## Benefits

Order of received first and sent second is restored.

## Applicable Issues

None.
