### PR TITLE
Account comparison awareness

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -172,6 +172,8 @@
     "tooltips": {
       "clear": "Clear selection",
       "comparison": "Compare accounts in one chart",
+      "comparisonWhenAccountsOption": "Account comparison is only available\nif more than one account is activated in add-on options",
+      "comparisonWhenFilter": "Account comparison is only available\nif 'All Accounts' is selected in accounts filter above",
       "error": {
         "dateFormat": "Format YYYY-MM-DD is required, e.g. 2020-01-31",
         "dateOrderEnd": "End date must be after start date",

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -275,16 +275,23 @@
 								</span>
 							</li>
 							<li
-								v-if="!loading && active.account == 'sum'"
-								class="cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto"
-								:data-tooltip="
-									!preferences.sections.total.comparison
-									? $t('stats.tooltips.comparison')
-									: $t('stats.tooltips.sum')
-								"
-								@click="preferences.sections.total.comparison=!preferences.sections.total.comparison"
+								class="tooltip tooltip-bottom px-1 ml-auto"
+								:class="{
+									'cursor-pointer': !singleAccount,
+									'text-hover-accent2': !singleAccount
+								}"
+								:data-tooltip="tooltipAccountComparison('total')"
+								@click="!singleAccount ? preferences.sections.total.comparison=!preferences.sections.total.comparison : null"
 							>
-								<svg class="icon icon-text icon-hover-accent" :class="{'icon-accent2': preferences.sections.total.comparison}" viewBox="0 0 24 24">
+								<svg
+									class="icon icon-text"
+									:class="{
+										'icon-hover-accent': !singleAccount,
+										'icon-accent2': preferences.sections.total.comparison && !singleAccount,
+										'icon-gray': singleAccount
+									}"
+									viewBox="0 0 24 24"
+								>
 									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
 									<rect class="icon-part-accent2" x="3" y="3" width="6" height="6" rx="1" />
 									<rect class="icon-part-accent1" x="15" y="15" width="6" height="6" rx="1" />
@@ -294,7 +301,6 @@
 							</li>
 							<li
 								class="resizer cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1"
-								:class="{ 'ml-auto': active.account != 'sum' || loading }"
 								:data-tooltip="
 									!preferences.sections.total.expand
 									? $t('stats.tooltips.expand')
@@ -458,16 +464,23 @@
 								</span>
 							</li>
 							<li
-								v-if="!loading && active.account == 'sum'"
-								class="cursor-pointer tooltip tooltip-bottom text-hover-accent2 px-1 ml-auto"
-								:data-tooltip="
-									!preferences.sections.onedim.comparison
-									? $t('stats.tooltips.comparison')
-									: $t('stats.tooltips.sum')
-								"
-								@click="preferences.sections.onedim.comparison=!preferences.sections.onedim.comparison"
+								class="tooltip tooltip-bottom px-1 ml-auto"
+								:class="{
+									'cursor-pointer': !singleAccount,
+									'text-hover-accent2': !singleAccount
+								}"
+								:data-tooltip="tooltipAccountComparison('onedim')"
+								@click="!singleAccount ? preferences.sections.onedim.comparison=!preferences.sections.onedim.comparison : null"
 							>
-								<svg class="icon icon-text icon-hover-accent" :class="{'icon-accent2': preferences.sections.onedim.comparison}" viewBox="0 0 24 24">
+								<svg
+									class="icon icon-text"
+									:class="{
+										'icon-hover-accent': !singleAccount,
+										'icon-accent2': preferences.sections.onedim.comparison && !singleAccount,
+										'icon-gray': singleAccount
+									}"
+									viewBox="0 0 24 24"
+								>
 									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
 									<rect class="icon-part-accent2" x="3" y="3" width="6" height="6" rx="1" />
 									<rect class="icon-part-accent1" x="15" y="15" width="6" height="6" rx="1" />
@@ -1543,6 +1556,19 @@ export default {
 				active: true,
 				url: url
 			})
+		},
+		// tooltip for account comparison button
+		// depends on active accounts, account selection and toggle of given section
+		tooltipAccountComparison (section) {
+			if (this.preferences.accounts.length < 2) {
+				return this.$t('stats.tooltips.comparisonWhenAccountsOption')
+			}
+			if (this.singleAccount) {
+				return this.$t('stats.tooltips.comparisonWhenFilter')
+			}
+			return !this.preferences.sections[section].comparison
+				? this.$t('stats.tooltips.comparison')
+				: this.$t('stats.tooltips.sum')
 		}
 	},
 	computed: {

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -710,7 +710,7 @@ loader(size, border)
 		transform: translate(-50%, .8rem)
 		transition: opacity transition.duration transition.function, transform transition.duration transition.function
 		white-space: pre
-		z-index: 5
+		z-index: 50
 		color: mode.dark.highlight
 		background: rgba(mode.dark.secondary2, .75)
 	&:focus, &:hover


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This makes the account comparison switch always visible. It's inactive if...
... only one account is active in add-on options
... a single account was selected in stats account filter

In both cases it shows a corresponding tooltip making clear, why this button is inactive.

In active state, the tooltip shows what happens if the button is clicked.

![image](https://user-images.githubusercontent.com/5441654/112680996-5cd5e300-8e6e-11eb-836b-029c6e2a2f55.png)

![image](https://user-images.githubusercontent.com/5441654/112680853-30ba6200-8e6e-11eb-9fa0-a10d7a1fa881.png)


## Benefits

Better UX because the user is way better informed about this feature.

## Applicable Issues

Closes #276 
