### PR TITLE
Include numbers in popup translations

### DIFF
--- a/public/_locales/ca/messages.json
+++ b/public/_locales/ca/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "Compte | Comptes",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} Compte | {0} Comptes"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "S",
       "quarter": "Q"
     },
+    "account": "Compte",
     "accountEmpty": "Aquest compte està buit, no hi ha cap correu electrònic.",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/cs/messages.json
+++ b/public/_locales/cs/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "Účet | Účtů",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} Účet | {0} Účtů"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "W",
       "quarter": "Q"
     },
+    "account": "Účet",
     "accountEmpty": "Tento účet je prázdný, nejsou tu žádné e-maily.",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/de/messages.json
+++ b/public/_locales/de/messages.json
@@ -2,199 +2,201 @@
   "extensionDescription": {
     "message": "Wunderschön visualisierte Statistiken für Thunderbird E-Mail-Konten"
   },
-  "popup": {
-    "account": "Konto | Konten",
-    "folder": "Ordner | Ordner",
-    "message": "-",
-    "openAllStats": "Alle Statistiken anzeigen",
-    "openOptions": "Einstellungen öffnen",
-    "messages": "Nachricht | Nachrichten"
-  },
-  "stats": {
-    "mailsTotal": "E-Mails gesamt",
-    "withinYears": "in {0} Jahren",
-    "mailsUnread": "E-Mails ungelesen",
-    "niceWork": "Gute Arbeit!",
-    "percentOfReceived": "{0}% von Empfangenen",
-    "mailsReceived": "E-Mails empfangen",
-    "percentOfTotal": "{0}% von Gesamt",
-    "mailsSent": "E-Mails gesendet",
-    "mailsPerMonth": "E-Mails pro Monat",
-    "mailsYear": "E-Mails/Jahr",
-    "mailsPerDay": "E-Mails pro Tag",
-    "mailsWeek": "E-Mails/Woche",
-    "loadingInProgress": "E-Mails für dieses Konto werden geladen…",
-    "accountEmpty": "Dieses Konto ist leer und enthält keine E-Mails.",
-    "timePeriod": "Zeitraum",
-    "charts": {
-      "years": {
-        "title": "Jahre",
-        "description": "Gesamtanzahl aller E-Mails pro Jahr"
-      },
-      "quarters": {
-        "title": "Quartale",
-        "description": "Gesamtanzahl aller E-Mails pro Quartal"
-      },
-      "months": {
-        "title": "Monate",
-        "description": "Gesamtanzahl aller E-Mails pro Monat"
-      },
-      "weeks": {
-        "title": "Wochen",
-        "description": "Gesamtanzahl aller E-Mails pro Woche"
-      },
-      "days": {
-        "title": "Aktivitäten in {0}",
-        "description": "Anzahl aller E-Mails pro Tag"
-      },
-      "daytime": {
-        "title": "Uhrzeit",
-        "description": "Anzahl aller E-Mails pro Stunde am Tag"
-      },
-      "weekday": {
-        "title": "Wochentag",
-        "description": "Anzahl aller E-Mails pro Wochentag"
-      },
-      "month": {
-        "title": "Monat",
-        "description": "Anzahl aller E-Mails pro Monat im Jahr"
-      },
-      "temporalDistribution": {
-        "title": "Zeitliche Verteilung",
-        "description": "Anzahl aller E-Mails pro Wochentag pro Stunde"
-      },
-      "contactsReceived": {
-        "title": "Häufigste Absender",
-        "description": "Anzahl empfangener E-Mails pro Absender"
-      },
-      "contactsSent": {
-        "title": "Häufigste Empfänger",
-        "description": "Anzahl gesendeter E-Mails pro Empfänger"
-      },
-      "foldersDistribution": {
-        "description": "Anzahl der E-Mails pro Ordner",
-        "title": "Ordnerverteilung"
-      },
-      "contactsJunk": {
-        "description": "Anzahl der E-Mails, die als Junk markiert sind, pro Absender",
-        "title": "Als Junk markiert"
-      }
-    },
-    "tooltips": {
-      "expand": "Bereich vergrößern",
-      "shrink": "Bereich verkleiner",
-      "refresh": "Daten aktualisieren",
-      "clear": "Auswahl aufheben",
-      "period": {
-        "start": "Startdatum\nTipp: '{0}' wird automatisch zu '{1}'",
-        "end": "Enddatum\nTipp: '{0}' wird automatisch zu '{1}'"
-      },
-      "error": {
-        "empty": "Eingabe ist erforderlich",
-        "dateFormat": "Format JJJJ-MM-TT ist erforderlich, z.B 2020-01-31",
-        "dateUnreal": "Ein gültiges Datum ist erforderlich",
-        "dateOrderStart": "Das Startdatum muss vor dem Enddatum liegen",
-        "dateOrderEnd": "Das Enddatum muss nach dem Startdatum liegen"
-      },
-      "folder": {
-        "notAvailable": "Ordner sind für {0} nicht verfügbar"
-      },
-      "comparison": "Vergleichsansicht aller Konten",
-      "sum": "Summe aller Konten anzeigen",
-      "exportData": "Aktuell angezeigte Daten als JSON-Datei exportieren",
-      "comparisonWhenAccountsOption": "Die Vergleichsansicht von Konten ist nur verfügbar,\nwenn in den Add-On-Optionen mehr als ein Konto aktiviert ist",
-      "comparisonWhenFilter": "Die Vergleichsansicht von Konten ist nur verfügbar,\nwenn im Filterbereich die Option \"Alle Konten\" ausgewählt ist"
-    },
-    "abbreviations": {
-      "calendarWeek": "KW",
-      "quarter": "Q",
-      "day": "d",
-      "hour": "h",
-      "minute": "min",
-      "second": "s"
-    },
-    "starAndImprove": "Mach mich zum Star auf <a href='{0}' target='_blank'>GitHub</a>.",
-    "message": "-",
-    "dataCollected": "Daten vor {0} abgerufen",
-    "allAccounts": "Alle Konten",
-    "nonEmptyFolders": "nicht leere Ordner | nicht leerer Ordner | nicht leere Ordner",
-    "contact": "Kontakt",
-    "disclaimer": "ThirdStats erhebt keinen Anspruch auf Korrektheit der angezeigten Daten.<br />Bei möglichen Problemen bitte  <a href='{0}' target='_blank'>einen Bug Report erstellen</a>.",
-    "junkMails": "Junk-Mails",
-    "junkScore": "Junk-Score von {0}"
-  },
   "options": {
+    "activeAccounts": {
+      "color": "Jedem Konto kann eine benutzerdefinierte Farbe zugewiesen werden, um die Konten im Vergleichsmodus zu unterscheiden.",
+      "description": "Einzelne Konten aktivieren oder deaktivieren. Deaktivierte Konten werden nicht gelistet und von der Statistik ausgeschlossen.",
+      "label": "Aktive Konten",
+      "sumAndCompare": "Wenn mehr als ein Konto aktiviert ist, ist die Filteroption \"Alle Konten\" für Summen- und Vergleichsansicht verfügbar."
+    },
+    "cache": {
+      "description": "Das Cache-System nutzen um bereits verarbeitete Statistikdaten schneller anzuzeigen",
+      "label": "Cache aktivieren"
+    },
+    "clearCache": {
+      "description": "Alle Statistikdaten aller Konten aus dem Cache löschen. Durch Öffnen der Statistikseite wird der Cache neu aufgebaut.",
+      "empty": "Der Cache ist leer",
+      "label": "Cache leeren",
+      "size": "Die Größe des Caches beträgt {0}"
+    },
+    "darkMode": {
+      "description": "Auswahl eines hellen oder dunklen Farbschemas",
+      "label": "Nachtmodus"
+    },
     "headings": {
       "appearance": "Aussehen & Nutzererlebnis",
       "stats": "Diagramme & Daten",
       "storage": "Speicher & Cache"
     },
-    "switch": {
-      "on": "An",
-      "off": "Aus"
-    },
-    "darkMode": {
-      "label": "Nachtmodus",
-      "description": "Auswahl eines hellen oder dunklen Farbschemas"
-    },
-    "ordinate": {
-      "label": "Vertikale Achse",
-      "description": "Vertikale Achse für alle Linien- und Balkendiagramme anzeigen"
+    "leaderCount": {
+      "description": "Anzahl der Einträge in Diagrammen welche häufige Kontakte auflisten (maximal 999)",
+      "label": "Anzahl häufiger Kontakte"
     },
     "localIdentities": {
-      "label": "Lokale Identitäten",
-      "description": "Eine kommagetrennte Liste von Absender E-Mail-Adressen für lokale Konten"
-    },
-    "startOfWeek": {
-      "label": "Die Woche startet am",
-      "description": "Benutzerdefinierter Wochenstart für alle wochentagsbezogenen Diagramme"
-    },
-    "activeAccounts": {
-      "label": "Aktive Konten",
-      "description": "Einzelne Konten aktivieren oder deaktivieren. Deaktivierte Konten werden nicht gelistet und von der Statistik ausgeschlossen.",
-      "color": "Jedem Konto kann eine benutzerdefinierte Farbe zugewiesen werden, um die Konten im Vergleichsmodus zu unterscheiden.",
-      "sumAndCompare": "Wenn mehr als ein Konto aktiviert ist, ist die Filteroption \"Alle Konten\" für Summen- und Vergleichsansicht verfügbar."
-    },
-    "cache": {
-      "label": "Cache aktivieren",
-      "description": "Das Cache-System nutzen um bereits verarbeitete Statistikdaten schneller anzuzeigen"
-    },
-    "clearCache": {
-      "label": "Cache leeren",
-      "description": "Alle Statistikdaten aller Konten aus dem Cache löschen. Durch Öffnen der Statistikseite wird der Cache neu aufgebaut.",
-      "empty": "Der Cache ist leer",
-      "size": "Die Größe des Caches beträgt {0}"
-    },
-    "note": {
-      "title": "Hinweis",
-      "reloadStatsPage": "Die Einstellungen werden automatisch gespeichert. Wenn die Statistikseite bereits geöffnet ist, muss diese neu geladen werden, damit Änderungen wirksam werden.",
-      "reloadWindowRequired": "Bei Änderung muss die Statistikseite neu geladen werden",
-      "refreshCacheRequired": "Bei Änderung muss der Cache neu erstellt werden"
+      "description": "Eine kommagetrennte Liste von Absender E-Mail-Adressen für lokale Konten",
+      "label": "Lokale Identitäten"
     },
     "message": "-",
+    "note": {
+      "refreshCacheRequired": "Bei Änderung muss der Cache neu erstellt werden",
+      "reloadStatsPage": "Die Einstellungen werden automatisch gespeichert. Wenn die Statistikseite bereits geöffnet ist, muss diese neu geladen werden, damit Änderungen wirksam werden.",
+      "reloadWindowRequired": "Bei Änderung muss die Statistikseite neu geladen werden",
+      "title": "Hinweis"
+    },
+    "ordinate": {
+      "description": "Vertikale Achse für alle Linien- und Balkendiagramme anzeigen",
+      "label": "Vertikale Achse"
+    },
+    "resetOptions": {
+      "description": "Alle Einstellungen auf die Standardwerte zurücksetzen.",
+      "label": "Einstellungen zurücksetzen",
+      "removeIdentities": "Dadurch werden auch alle lokalen Identitäten gelöscht."
+    },
     "selfMessages": {
-      "label": "Eigennachrichten",
       "description": "Nachrichten ausschließen, die von mir an mich selbst gesendet wurden",
-      "values": {
-        "none": "Deaktiviert",
-        "sameAccount": "Vom gleichen Konto",
-        "anyAccount": "Von jedem Konto"
-      },
       "info": {
+        "anyAccount": "Nachrichten, bei denen sowohl Absender als auch Empfänger Identitäten eines beliebigen Kontos sind, werden ausgeschlossen",
         "none": "Eigennachrichten werden einbezogen und als normale E-Mails behandelt (Standard)",
-        "sameAccount": "Nachrichten, bei denen sowohl Absender als auch Empfänger Identitäten desselben Kontos sind, werden ausgeschlossen",
-        "anyAccount": "Nachrichten, bei denen sowohl Absender als auch Empfänger Identitäten eines beliebigen Kontos sind, werden ausgeschlossen"
+        "sameAccount": "Nachrichten, bei denen sowohl Absender als auch Empfänger Identitäten desselben Kontos sind, werden ausgeschlossen"
+      },
+      "label": "Eigennachrichten",
+      "values": {
+        "anyAccount": "Von jedem Konto",
+        "none": "Deaktiviert",
+        "sameAccount": "Vom gleichen Konto"
       }
     },
-    "leaderCount": {
-      "label": "Anzahl häufiger Kontakte",
-      "description": "Anzahl der Einträge in Diagrammen welche häufige Kontakte auflisten (maximal 999)"
+    "startOfWeek": {
+      "description": "Benutzerdefinierter Wochenstart für alle wochentagsbezogenen Diagramme",
+      "label": "Die Woche startet am"
     },
-    "title": "Einstellungen",
-    "resetOptions": {
-      "label": "Einstellungen zurücksetzen",
-      "description": "Alle Einstellungen auf die Standardwerte zurücksetzen.",
-      "removeIdentities": "Dadurch werden auch alle lokalen Identitäten gelöscht."
-    }
+    "switch": {
+      "off": "Aus",
+      "on": "An"
+    },
+    "title": "Einstellungen"
+  },
+  "popup": {
+    "message": "-",
+    "nAccounts": "{0} Konto | {0} Konten",
+    "nFolders": "{0} Ordner | {0} Ordner",
+    "nMessages": "{0} Nachricht | {0} Nachrichten",
+    "openAllStats": "Alle Statistiken anzeigen",
+    "openOptions": "Einstellungen öffnen"
+  },
+  "stats": {
+    "abbreviations": {
+      "calendarWeek": "KW",
+      "day": "d",
+      "hour": "h",
+      "minute": "min",
+      "quarter": "Q",
+      "second": "s"
+    },
+    "account": "Konto",
+    "accountEmpty": "Dieses Konto ist leer und enthält keine E-Mails.",
+    "allAccounts": "Alle Konten",
+    "charts": {
+      "contactsJunk": {
+        "description": "Anzahl der E-Mails, die als Junk markiert sind, pro Absender",
+        "title": "Als Junk markiert"
+      },
+      "contactsReceived": {
+        "description": "Anzahl empfangener E-Mails pro Absender",
+        "title": "Häufigste Absender"
+      },
+      "contactsSent": {
+        "description": "Anzahl gesendeter E-Mails pro Empfänger",
+        "title": "Häufigste Empfänger"
+      },
+      "days": {
+        "description": "Anzahl aller E-Mails pro Tag",
+        "title": "Aktivitäten in {0}"
+      },
+      "daytime": {
+        "description": "Anzahl aller E-Mails pro Stunde am Tag",
+        "title": "Uhrzeit"
+      },
+      "foldersDistribution": {
+        "description": "Anzahl der E-Mails pro Ordner",
+        "title": "Ordnerverteilung"
+      },
+      "month": {
+        "description": "Anzahl aller E-Mails pro Monat im Jahr",
+        "title": "Monat"
+      },
+      "months": {
+        "description": "Gesamtanzahl aller E-Mails pro Monat",
+        "title": "Monate"
+      },
+      "quarters": {
+        "description": "Gesamtanzahl aller E-Mails pro Quartal",
+        "title": "Quartale"
+      },
+      "temporalDistribution": {
+        "description": "Anzahl aller E-Mails pro Wochentag pro Stunde",
+        "title": "Zeitliche Verteilung"
+      },
+      "weekday": {
+        "description": "Anzahl aller E-Mails pro Wochentag",
+        "title": "Wochentag"
+      },
+      "weeks": {
+        "description": "Gesamtanzahl aller E-Mails pro Woche",
+        "title": "Wochen"
+      },
+      "years": {
+        "description": "Gesamtanzahl aller E-Mails pro Jahr",
+        "title": "Jahre"
+      }
+    },
+    "contact": "Kontakt",
+    "dataCollected": "Daten vor {0} abgerufen",
+    "disclaimer": "ThirdStats erhebt keinen Anspruch auf Korrektheit der angezeigten Daten.<br />Bei möglichen Problemen bitte  <a href='{0}' target='_blank'>einen Bug Report erstellen</a>.",
+    "folder": "Ordner",
+    "junkMails": "Junk-Mails",
+    "junkScore": "Junk-Score von {0}",
+    "loadingInProgress": "E-Mails für dieses Konto werden geladen…",
+    "mailsPerDay": "E-Mails pro Tag",
+    "mailsPerMonth": "E-Mails pro Monat",
+    "mailsReceived": "E-Mails empfangen",
+    "mailsSent": "E-Mails gesendet",
+    "mailsTotal": "E-Mails gesamt",
+    "mailsUnread": "E-Mails ungelesen",
+    "mailsWeek": "E-Mails/Woche",
+    "mailsYear": "E-Mails/Jahr",
+    "message": "-",
+    "niceWork": "Gute Arbeit!",
+    "nonEmptyFolders": "nicht leere Ordner | nicht leerer Ordner | nicht leere Ordner",
+    "percentOfReceived": "{0}% von Empfangenen",
+    "percentOfTotal": "{0}% von Gesamt",
+    "starAndImprove": "Mach mich zum Star auf <a href='{0}' target='_blank'>GitHub</a>.",
+    "timePeriod": "Zeitraum",
+    "tooltips": {
+      "clear": "Auswahl aufheben",
+      "comparison": "Vergleichsansicht aller Konten",
+      "comparisonWhenAccountsOption": "Die Vergleichsansicht von Konten ist nur verfügbar,\nwenn in den Add-On-Optionen mehr als ein Konto aktiviert ist",
+      "comparisonWhenFilter": "Die Vergleichsansicht von Konten ist nur verfügbar,\nwenn im Filterbereich die Option \"Alle Konten\" ausgewählt ist",
+      "error": {
+        "dateFormat": "Format JJJJ-MM-TT ist erforderlich, z.B 2020-01-31",
+        "dateOrderEnd": "Das Enddatum muss nach dem Startdatum liegen",
+        "dateOrderStart": "Das Startdatum muss vor dem Enddatum liegen",
+        "dateUnreal": "Ein gültiges Datum ist erforderlich",
+        "empty": "Eingabe ist erforderlich"
+      },
+      "expand": "Bereich vergrößern",
+      "exportData": "Aktuell angezeigte Daten als JSON-Datei exportieren",
+      "folder": {
+        "notAvailable": "Ordner sind für {0} nicht verfügbar"
+      },
+      "period": {
+        "end": "Enddatum\nTipp: '{0}' wird automatisch zu '{1}'",
+        "start": "Startdatum\nTipp: '{0}' wird automatisch zu '{1}'"
+      },
+      "refresh": "Daten aktualisieren",
+      "shrink": "Bereich verkleiner",
+      "sum": "Summe aller Konten anzeigen"
+    },
+    "withinYears": "in {0} Jahren"
   }
 }

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -77,10 +77,10 @@
     "title": "Options"
   },
   "popup": {
-    "account": "Account | Accounts",
-    "folder": "Folder | Folders",
     "message": "-",
-    "messages": "Message | Messages",
+    "nAccounts": "{0} Account | {0} Accounts",
+    "nFolders": "{0} Folder | {0} Folders",
+    "nMessages": "{0} Message | {0} Messages",
     "openAllStats": "Open all Stats",
     "openOptions": "Open Options"
   },
@@ -93,6 +93,7 @@
       "quarter": "Q",
       "second": "s"
     },
+    "account": "Account",
     "accountEmpty": "This account is empty, no emails here.",
     "allAccounts": "All Accounts",
     "charts": {
@@ -152,6 +153,7 @@
     "contact": "Contact",
     "dataCollected": "Data collected {0} ago",
     "disclaimer": "ThirdStats makes no claim to the correctness of the data displayed.<br />In case of possible problems, please <a href='{0}' target='_blank'>create a bug report</a>.",
+    "folder": "Folder",
     "junkMails": "Junk mails",
     "junkScore": "Junk score of {0}",
     "loadingInProgress": "Loading of all emails from this account in progress…",

--- a/public/_locales/es/messages.json
+++ b/public/_locales/es/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "Cuenta | Cuentas",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} Cuenta | {0} Cuentas"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "S",
       "quarter": "C"
     },
+    "account": "Cuenta",
     "accountEmpty": "Esta cuenta está vacía, aquí no hay correos.",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/fr/messages.json
+++ b/public/_locales/fr/messages.json
@@ -2,199 +2,201 @@
   "extensionDescription": {
     "message": "Statistiques magnifiquement affichées pour vos comptes de courrier Thunderbird"
   },
-  "popup": {
-    "account": "Compte | Comptes",
-    "folder": "Dossier | Dossiers",
-    "message": "-",
-    "openAllStats": "Ouvrir toutes les statistiques",
-    "openOptions": "Ouvrir les options",
-    "messages": "Message | messages"
-  },
-  "stats": {
-    "mailsTotal": "Total des messages",
-    "withinYears": "en {0} ans",
-    "mailsUnread": "Messages non lus",
-    "niceWork": "Beau travail !",
-    "percentOfReceived": "{0}% des reçus",
-    "mailsReceived": "Messages reçus",
-    "percentOfTotal": "{0}% du total",
-    "mailsSent": "Message(s) envoyé(s)",
-    "mailsPerMonth": "Message(s) par mois",
-    "mailsYear": "message(s)/an(s)",
-    "mailsPerDay": "Message(s) par jour",
-    "mailsWeek": "message(s)/semaine",
-    "loadingInProgress": "Chargement des emails du compte en cours…",
-    "accountEmpty": "Ce compte est vide, il n'y a pas d'emails.",
-    "timePeriod": "Période de temps",
-    "charts": {
-      "years": {
-        "title": "Ans",
-        "description": "Nombre total de messages par an"
-      },
-      "quarters": {
-        "title": "Trimestre",
-        "description": "Nombre total de messages par trimestre"
-      },
-      "months": {
-        "title": "Mois",
-        "description": "Nombre total de messages par mois"
-      },
-      "weeks": {
-        "title": "Semaine",
-        "description": "Nombre total de messages par semaine"
-      },
-      "days": {
-        "title": "Activité dans {0}",
-        "description": "Nombre de messages par jour"
-      },
-      "daytime": {
-        "title": "Journée",
-        "description": "Nombre de messages par heure de la journée"
-      },
-      "weekday": {
-        "title": "Jour de la semaine",
-        "description": "Nombre de messages par jour de la semaine"
-      },
-      "month": {
-        "title": "Mois",
-        "description": "Nombre total de messages par mois"
-      },
-      "temporalDistribution": {
-        "title": "Distribution temporelle",
-        "description": "Nombre de messages par jour de la semaine par heure"
-      },
-      "contactsReceived": {
-        "title": "La plupart ont été reçus de",
-        "description": "Nombre d'emails reçus par destinataire"
-      },
-      "contactsSent": {
-        "title": "La plupart ont été envoyés à",
-        "description": "Nombre d'emails envoyés par expéditeur"
-      },
-      "foldersDistribution": {
-        "description": "Nombre d'e-mails par dossier",
-        "title": "Distribution des dossiers"
-      },
-      "contactsJunk": {
-        "description": "Nombre d'e-mails marqués comme indésirables par expéditeur",
-        "title": "Marqué comme indésirable"
-      }
-    },
-    "tooltips": {
-      "expand": "Agrandir la zone du graphique",
-      "shrink": "Rétrécir la zone du graphique",
-      "refresh": "Actualiser les données",
-      "clear": "Effacer la sélection",
-      "period": {
-        "start": "De ce jour\nConseil: taper «{0}» devient «{1}»",
-        "end": "À ce jour\nConseil: taper «{0}» devient «{1}»"
-      },
-      "error": {
-        "empty": "Une entrée est requise",
-        "dateFormat": "Le format AAAA-MM-JJ est requis, par ex. 2020-01-31",
-        "dateUnreal": "Une date valide est requise",
-        "dateOrderStart": "La date de début doit être antérieure à la date de fin",
-        "dateOrderEnd": "La date de fin doit être postérieure à la date de début"
-      },
-      "folder": {
-        "notAvailable": "Les dossiers ne sont pas disponibles pour {0}"
-      },
-      "comparison": "Comparez les comptes",
-      "sum": "La somme de tous les comptes",
-      "exportData": "Exporter les données actuellement affichées sous forme de fichier JSON",
-      "comparisonWhenAccountsOption": "La comparaison de compte est uniquement disponible\nsi plusieurs comptes sont activés dans les options",
-      "comparisonWhenFilter": "La comparaison de compte est uniquement disponible\nsi \"Tous les comptes\" est sélectionné dans le filtre des comptes"
-    },
-    "abbreviations": {
-      "calendarWeek": "S",
-      "quarter": "T",
-      "day": "jour",
-      "hour": "h",
-      "minute": "min",
-      "second": "s"
-    },
-    "starAndImprove": "Star et améliore ce projet sur <a href='{0}' target='_blank'>Github</a>",
-    "message": "-",
-    "dataCollected": "Données collectées il y a {0}",
-    "allAccounts": "Tous les comptes",
-    "nonEmptyFolders": "dossiers non vides | dossier non vide | dossiers non vides",
-    "contact": "Contact",
-    "disclaimer": "ThirdStats ne prétend pas à l'exactitude des données affichées.<br />En cas de problèmes éventuels, veuillez <a href='{0}' target='_blank'>créer un rapport de bogue</a>.",
-    "junkMails": "Courriers indésirables",
-    "junkScore": "Score indésirable de {0}"
-  },
   "options": {
+    "activeAccounts": {
+      "color": "Donnez une couleur personnalisée à chaque compte pour les distinguer en mode comparaison.",
+      "description": "Activez ou désactivez les comptes. Les comptes désactivés n'apparaîtront dans aucune liste de comptes ou statistiques.",
+      "label": "Comptes actifs",
+      "sumAndCompare": "L'activation de plusieurs comptes active l'option de filtre de statistiques «Tous les comptes» pour la vue de somme et de comparaison."
+    },
+    "cache": {
+      "description": "Activez le système de mise en cache pour un affichage plus rapide des données de statistiques déjà traitées.",
+      "label": "Activer le cache"
+    },
+    "clearCache": {
+      "description": "Supprimez toutes les données de statistiques mises en cache de tous les comptes. Sera reconstruit en ouvrant à nouveau la page de statistiques.",
+      "empty": "Le cache est vide",
+      "label": "Vider le cache",
+      "size": "La taille du cache est de {0}"
+    },
+    "darkMode": {
+      "description": "Passer du mode sombre au mode clair",
+      "label": "Mode sombre"
+    },
     "headings": {
       "appearance": "Apparence et Expérience",
       "stats": "Graphiques et Données",
       "storage": "Stockage et Cache"
     },
-    "switch": {
-      "on": "Marche",
-      "off": "Arrêt"
-    },
-    "darkMode": {
-      "label": "Mode sombre",
-      "description": "Passer du mode sombre au mode clair"
-    },
-    "ordinate": {
-      "label": "Axe vertical",
-      "description": "Afficher l'axe vertical pour tous les graphiques en lignes et en barres"
+    "leaderCount": {
+      "description": "Nombre d'entrées figurant dans les tableaux des contacts fréquents (999 au maximum)",
+      "label": "Tableau de classement"
     },
     "localIdentities": {
-      "label": "Identités locales",
-      "description": "Une liste d'adresses électroniques, séparées par des virgules, à reconnaître comme 'envoyées de' pour les comptes locaux"
-    },
-    "startOfWeek": {
-      "label": "Commencer la semaine le",
-      "description": "Début de semaine personnalisé pour tous les graphiques liés à la semaine"
-    },
-    "activeAccounts": {
-      "label": "Comptes actifs",
-      "description": "Activez ou désactivez les comptes. Les comptes désactivés n'apparaîtront dans aucune liste de comptes ou statistiques.",
-      "color": "Donnez une couleur personnalisée à chaque compte pour les distinguer en mode comparaison.",
-      "sumAndCompare": "L'activation de plusieurs comptes active l'option de filtre de statistiques «Tous les comptes» pour la vue de somme et de comparaison."
-    },
-    "cache": {
-      "label": "Activer le cache",
-      "description": "Activez le système de mise en cache pour un affichage plus rapide des données de statistiques déjà traitées."
-    },
-    "clearCache": {
-      "label": "Vider le cache",
-      "description": "Supprimez toutes les données de statistiques mises en cache de tous les comptes. Sera reconstruit en ouvrant à nouveau la page de statistiques.",
-      "empty": "Le cache est vide",
-      "size": "La taille du cache est de {0}"
-    },
-    "note": {
-      "title": "Remarque",
-      "reloadStatsPage": "Les options sont automatiquement enregistrées. Si la page de statistiques est déjà ouverte, vous devez la rouvrir ou la recharger pour que les modifications soient appliquées.",
-      "reloadWindowRequired": "En cas de modification, la fenêtre de statistiques doit être rechargée",
-      "refreshCacheRequired": "En cas de modifications, le cache doit être reconstruit"
+      "description": "Une liste d'adresses électroniques, séparées par des virgules, à reconnaître comme 'envoyées de' pour les comptes locaux",
+      "label": "Identités locales"
     },
     "message": "-",
+    "note": {
+      "refreshCacheRequired": "En cas de modifications, le cache doit être reconstruit",
+      "reloadStatsPage": "Les options sont automatiquement enregistrées. Si la page de statistiques est déjà ouverte, vous devez la rouvrir ou la recharger pour que les modifications soient appliquées.",
+      "reloadWindowRequired": "En cas de modification, la fenêtre de statistiques doit être rechargée",
+      "title": "Remarque"
+    },
+    "ordinate": {
+      "description": "Afficher l'axe vertical pour tous les graphiques en lignes et en barres",
+      "label": "Axe vertical"
+    },
+    "resetOptions": {
+      "description": "Réinitialisez toutes les options à leurs valeurs par défaut.",
+      "label": "Réinitialiser les options",
+      "removeIdentities": "Cela supprimera également toutes les identités locales que vous avez créées."
+    },
     "selfMessages": {
-      "label": "Messages internes",
       "description": "Exclure les messages qui m'ont été envoyés à moi-même",
-      "values": {
-        "none": "désactivé",
-        "sameAccount": "Même compte seulement",
-        "anyAccount": "Depuis n'importe quel compte"
-      },
       "info": {
+        "anyAccount": "Les messages dont l'expéditeur et le destinataire sont des identités de n'importe quel compte seront exclus",
         "none": "Les messages internes seront inclus et traités comme des e-mails normaux (par défaut)",
-        "sameAccount": "Les messages dont l'expéditeur et le destinataire sont des identités du même compte seront exclus",
-        "anyAccount": "Les messages dont l'expéditeur et le destinataire sont des identités de n'importe quel compte seront exclus"
+        "sameAccount": "Les messages dont l'expéditeur et le destinataire sont des identités du même compte seront exclus"
+      },
+      "label": "Messages internes",
+      "values": {
+        "anyAccount": "Depuis n'importe quel compte",
+        "none": "désactivé",
+        "sameAccount": "Même compte seulement"
       }
     },
-    "leaderCount": {
-      "label": "Tableau de classement",
-      "description": "Nombre d'entrées figurant dans les tableaux des contacts fréquents (999 au maximum)"
+    "startOfWeek": {
+      "description": "Début de semaine personnalisé pour tous les graphiques liés à la semaine",
+      "label": "Commencer la semaine le"
     },
-    "title": "Options",
-    "resetOptions": {
-      "label": "Réinitialiser les options",
-      "description": "Réinitialisez toutes les options à leurs valeurs par défaut.",
-      "removeIdentities": "Cela supprimera également toutes les identités locales que vous avez créées."
-    }
+    "switch": {
+      "off": "Arrêt",
+      "on": "Marche"
+    },
+    "title": "Options"
+  },
+  "popup": {
+    "message": "-",
+    "nAccounts": "{0} Compte | {0} Comptes",
+    "nFolders": "{0} Dossier | {0} Dossiers",
+    "nMessages": "{0} Message | {0} Messages",
+    "openAllStats": "Ouvrir toutes les statistiques",
+    "openOptions": "Ouvrir les options"
+  },
+  "stats": {
+    "abbreviations": {
+      "calendarWeek": "S",
+      "day": "jour",
+      "hour": "h",
+      "minute": "min",
+      "quarter": "T",
+      "second": "s"
+    },
+    "account": "Compte",
+    "accountEmpty": "Ce compte est vide, il n'y a pas d'emails.",
+    "allAccounts": "Tous les comptes",
+    "charts": {
+      "contactsJunk": {
+        "description": "Nombre d'e-mails marqués comme indésirables par expéditeur",
+        "title": "Marqué comme indésirable"
+      },
+      "contactsReceived": {
+        "description": "Nombre d'emails reçus par destinataire",
+        "title": "La plupart ont été reçus de"
+      },
+      "contactsSent": {
+        "description": "Nombre d'emails envoyés par expéditeur",
+        "title": "La plupart ont été envoyés à"
+      },
+      "days": {
+        "description": "Nombre de messages par jour",
+        "title": "Activité dans {0}"
+      },
+      "daytime": {
+        "description": "Nombre de messages par heure de la journée",
+        "title": "Journée"
+      },
+      "foldersDistribution": {
+        "description": "Nombre d'e-mails par dossier",
+        "title": "Distribution des dossiers"
+      },
+      "month": {
+        "description": "Nombre total de messages par mois",
+        "title": "Mois"
+      },
+      "months": {
+        "description": "Nombre total de messages par mois",
+        "title": "Mois"
+      },
+      "quarters": {
+        "description": "Nombre total de messages par trimestre",
+        "title": "Trimestre"
+      },
+      "temporalDistribution": {
+        "description": "Nombre de messages par jour de la semaine par heure",
+        "title": "Distribution temporelle"
+      },
+      "weekday": {
+        "description": "Nombre de messages par jour de la semaine",
+        "title": "Jour de la semaine"
+      },
+      "weeks": {
+        "description": "Nombre total de messages par semaine",
+        "title": "Semaine"
+      },
+      "years": {
+        "description": "Nombre total de messages par an",
+        "title": "Ans"
+      }
+    },
+    "contact": "Contact",
+    "dataCollected": "Données collectées il y a {0}",
+    "disclaimer": "ThirdStats ne prétend pas à l'exactitude des données affichées.<br />En cas de problèmes éventuels, veuillez <a href='{0}' target='_blank'>créer un rapport de bogue</a>.",
+    "folder": "Dossier",
+    "junkMails": "Courriers indésirables",
+    "junkScore": "Score indésirable de {0}",
+    "loadingInProgress": "Chargement des emails du compte en cours…",
+    "mailsPerDay": "Message(s) par jour",
+    "mailsPerMonth": "Message(s) par mois",
+    "mailsReceived": "Messages reçus",
+    "mailsSent": "Message(s) envoyé(s)",
+    "mailsTotal": "Total des messages",
+    "mailsUnread": "Messages non lus",
+    "mailsWeek": "message(s)/semaine",
+    "mailsYear": "message(s)/an(s)",
+    "message": "-",
+    "niceWork": "Beau travail !",
+    "nonEmptyFolders": "dossiers non vides | dossier non vide | dossiers non vides",
+    "percentOfReceived": "{0}% des reçus",
+    "percentOfTotal": "{0}% du total",
+    "starAndImprove": "Star et améliore ce projet sur <a href='{0}' target='_blank'>Github</a>",
+    "timePeriod": "Période de temps",
+    "tooltips": {
+      "clear": "Effacer la sélection",
+      "comparison": "Comparez les comptes",
+      "comparisonWhenAccountsOption": "La comparaison de compte est uniquement disponible\nsi plusieurs comptes sont activés dans les options",
+      "comparisonWhenFilter": "La comparaison de compte est uniquement disponible\nsi \"Tous les comptes\" est sélectionné dans le filtre des comptes",
+      "error": {
+        "dateFormat": "Le format AAAA-MM-JJ est requis, par ex. 2020-01-31",
+        "dateOrderEnd": "La date de fin doit être postérieure à la date de début",
+        "dateOrderStart": "La date de début doit être antérieure à la date de fin",
+        "dateUnreal": "Une date valide est requise",
+        "empty": "Une entrée est requise"
+      },
+      "expand": "Agrandir la zone du graphique",
+      "exportData": "Exporter les données actuellement affichées sous forme de fichier JSON",
+      "folder": {
+        "notAvailable": "Les dossiers ne sont pas disponibles pour {0}"
+      },
+      "period": {
+        "end": "À ce jour\nConseil: taper «{0}» devient «{1}»",
+        "start": "De ce jour\nConseil: taper «{0}» devient «{1}»"
+      },
+      "refresh": "Actualiser les données",
+      "shrink": "Rétrécir la zone du graphique",
+      "sum": "La somme de tous les comptes"
+    },
+    "withinYears": "en {0} ans"
   }
 }

--- a/public/_locales/gl/messages.json
+++ b/public/_locales/gl/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "Conta | Contas",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} Conta | {0} Contas"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "S",
       "quarter": "T"
     },
+    "account": "Conta",
     "accountEmpty": "Esta conta non ten ningún correo.",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/hi/messages.json
+++ b/public/_locales/hi/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "खाता | खाते",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} खाता | {0} खाते"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "W",
       "quarter": "Q"
     },
+    "account": "खाता",
     "accountEmpty": "इस खाते में कोई मेल नहीं है।",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/hu/messages.json
+++ b/public/_locales/hu/messages.json
@@ -2,199 +2,201 @@
   "extensionDescription": {
     "message": "Gyönyörűen megjelenített statisztikák a Thunderbird levelező postafiókokhoz"
   },
-  "popup": {
-    "account": "Fiók",
-    "folder": "Mappa",
-    "message": "-",
-    "openAllStats": "Az összes statisztika megnyitása",
-    "openOptions": "Beállítások megnyitása",
-    "messages": "Üzenet"
-  },
-  "stats": {
-    "mailsTotal": "Levelek összesen",
-    "withinYears": "{0} éven belül",
-    "mailsUnread": "Mails unread",
-    "niceWork": "Szép munka!",
-    "percentOfReceived": "A beérkezett adatok {0}%-a",
-    "mailsReceived": "Levelek fogadva",
-    "percentOfTotal": "Az összes {0}%-a",
-    "mailsSent": "Levelek elküldve",
-    "mailsPerMonth": "Levél havonta",
-    "mailsYear": "levél/év",
-    "mailsPerDay": "Levél naponta",
-    "mailsWeek": "levél/hét",
-    "loadingInProgress": "A fiók összes e-mailének betöltése folyamatban van…",
-    "accountEmpty": "Ez a postafiók üres, itt nincsenek e-mailek.",
-    "timePeriod": "Dátumtartomány",
-    "charts": {
-      "years": {
-        "title": "Évek",
-        "description": "Éves e-mailek teljes száma"
-      },
-      "quarters": {
-        "title": "Negyedek",
-        "description": "Az e-mailek száma negyedévenként"
-      },
-      "months": {
-        "title": "Hónapok",
-        "description": "E-mailek teljes száma havonta"
-      },
-      "weeks": {
-        "title": "Hetek",
-        "description": "Heti e-mailek teljes száma"
-      },
-      "days": {
-        "title": "Tevékenység itt: {0}",
-        "description": "E-mailek száma dátum szerint"
-      },
-      "daytime": {
-        "title": "Nappal",
-        "description": "E-mailek száma napszakonként"
-      },
-      "weekday": {
-        "title": "Hétköznap",
-        "description": "E-mailek száma a hét minden napján"
-      },
-      "month": {
-        "title": "Hónap",
-        "description": "E-mailek száma az év hónapjában"
-      },
-      "temporalDistribution": {
-        "title": "Időbeli eloszlása",
-        "description": "Hétköznap / óra e-mailek száma"
-      },
-      "contactsReceived": {
-        "title": "A legtöbb kapott",
-        "description": "Feladónként kapott e-mailek száma"
-      },
-      "contactsSent": {
-        "title": "A legtöbbet elküldték",
-        "description": "A címzettenként elküldött e-mailek száma"
-      },
-      "foldersDistribution": {
-        "description": "E-mailek száma mappánként",
-        "title": "Mappák terjesztése"
-      },
-      "contactsJunk": {
-        "description": "Levélszemétként megjelölt e-mailek száma küldőnként",
-        "title": "Levélszemétként megjelölve"
-      }
-    },
-    "tooltips": {
-      "expand": "Diagramterület kibontása",
-      "shrink": "Diagramterület csökkentése",
-      "refresh": "Adatok frissítése",
-      "clear": "Kijelölés törlése",
-      "period": {
-        "start": "Dátumtól\nTipp: A(z) „{0}” begépelése „{1}” lesz",
-        "end": "Dátumig\nTipp: A(z) „{0}” begépelése „{1}” lesz"
-      },
-      "error": {
-        "empty": "Bevitel szükséges",
-        "dateFormat": "Formátum: ÉÉÉÉ-HH-NN szükséges, pl. 2020-01-31",
-        "dateUnreal": "Érvényes dátumot kell megadni",
-        "dateOrderStart": "A kezdő dátumnak a befejezés dátuma előtt kell lennie",
-        "dateOrderEnd": "A befejezés dátumának a kezdő dátum után kell lennie"
-      },
-      "folder": {
-        "notAvailable": "A(z) {0} mappák nem érhetők el"
-      },
-      "comparison": "Fiókok összehasonlítása egy diagramban",
-      "sum": "Az összes fiók összegének megjelenítése",
-      "exportData": "Exportálja a jelenleg megjelenített adatokat JSON fájlként",
-      "comparisonWhenAccountsOption": "A fiókok összehasonlítása csak akkor érhető el, ha egynél több fiók engedélyezett a kiegészítő beállításokban",
-      "comparisonWhenFilter": "A fiókok összehasonlítása csak akkor érhető el, ha a fenti fiókszűrőben az „Összes fiók” van kiválasztva."
-    },
-    "abbreviations": {
-      "calendarWeek": "h",
-      "quarter": "¼",
-      "day": "n",
-      "hour": "ó",
-      "minute": "p",
-      "second": "mp"
-    },
-    "starAndImprove": "Légy sztár, villálj a <a href='{0}' target='_blank'>GitHub</a>on.",
-    "message": "-",
-    "dataCollected": "{0} ezelőtt gyűjtött adatok",
-    "allAccounts": "Minden postafiók",
-    "nonEmptyFolders": "nem üres mappák | nem üres mappa | nem üres mappák",
-    "contact": "Névjegy",
-    "disclaimer": "A ThirdStats nem hivatkozik a megjelenített adatok helyességére.<br />Lehetséges problémák esetén kérjük <a href='{0}' target='_blank'>hozzon létre hibajelentést</a>.",
-    "junkMails": "Levélszemetek",
-    "junkScore": "{0} levélszemét pontszám"
-  },
   "options": {
+    "activeAccounts": {
+      "color": "Adjon minden fióknak egyéni színt, hogy megkülönböztesse őket összehasonlítási módban.",
+      "description": "Fiókok engedélyezése vagy letiltása. A letiltott fiókok nem jelennek meg a fióklistában vagy a statisztikákban.",
+      "label": "Elérhető fiókok",
+      "sumAndCompare": "Több fiók aktiválása engedélyezi az „Összes fiók” statisztika szűrő opciót összeg és összehasonlító nézethez."
+    },
+    "cache": {
+      "description": "A gyorsítótár-rendszer engedélyezése a már feldolgozott statisztikai adatok gyorsabb megjelenítéséhez.",
+      "label": "Gyorsítótár engedélyezése"
+    },
+    "clearCache": {
+      "description": "Távolítsa el az összes gyorsítótárazott statisztikai adatot az összes fiókból. A statisztika oldal újbóli megnyitásával újjáépül.",
+      "empty": "A gyorsítótár üres",
+      "label": "Gyorsítótár törlése",
+      "size": "A gyorsítótár fájlmérete: {0}"
+    },
+    "darkMode": {
+      "description": "Sötét és világos színvilág váltása",
+      "label": "Sötét mód"
+    },
     "headings": {
       "appearance": "Megjelenés és tapasztalat",
       "stats": "Diagramok és adatok",
       "storage": "Tárolás és gyorsítótár"
     },
-    "switch": {
-      "on": "Be",
-      "off": "Ki"
-    },
-    "darkMode": {
-      "label": "Sötét mód",
-      "description": "Sötét és világos színvilág váltása"
-    },
-    "ordinate": {
-      "label": "Függőleges tengely",
-      "description": "A függőleges tengely megjelenítése az összes vonalas és oszlopdiagramon"
+    "leaderCount": {
+      "description": "A gyakori kapcsolattartókat felsoroló diagramokban szereplő bejegyzések száma (legfeljebb 999)",
+      "label": "Vezérszám"
     },
     "localIdentities": {
-      "label": "Helyi személyazonosságok",
-      "description": "A lista e-mail címét, hogy ismerje a „küldött” a helyi fiókok"
-    },
-    "startOfWeek": {
-      "label": "Kezdje a hetet",
-      "description": "A hét egyéni kezdete az összes hétköznapi diagramhoz"
-    },
-    "activeAccounts": {
-      "label": "Elérhető fiókok",
-      "description": "Fiókok engedélyezése vagy letiltása. A letiltott fiókok nem jelennek meg a fióklistában vagy a statisztikákban.",
-      "color": "Adjon minden fióknak egyéni színt, hogy megkülönböztesse őket összehasonlítási módban.",
-      "sumAndCompare": "Több fiók aktiválása engedélyezi az „Összes fiók” statisztika szűrő opciót összeg és összehasonlító nézethez."
-    },
-    "cache": {
-      "label": "Gyorsítótár engedélyezése",
-      "description": "A gyorsítótár-rendszer engedélyezése a már feldolgozott statisztikai adatok gyorsabb megjelenítéséhez."
-    },
-    "clearCache": {
-      "label": "Gyorsítótár törlése",
-      "description": "Távolítsa el az összes gyorsítótárazott statisztikai adatot az összes fiókból. A statisztika oldal újbóli megnyitásával újjáépül.",
-      "empty": "A gyorsítótár üres",
-      "size": "A gyorsítótár fájlmérete: {0}"
-    },
-    "note": {
-      "title": "Megjegyzés",
-      "reloadStatsPage": "Az opciók önműködően mentésre kerülnek. Bizonyos opcióváltozások nem alkalmazhatók önműködően a már megnyitott statisztikai oldalra vagy a meglévő gyorsítótár bejegyzésekre, ha a gyorsítótár aktiválva van. Megfelelő ikonokkal vannak jelölve.",
-      "reloadWindowRequired": "Ha megváltoztatja, a statisztika ablakot újra be kell tölteni",
-      "refreshCacheRequired": "Ha megváltozik, akkor a gyorsítótárat újra kell építeni"
+      "description": "A lista e-mail címét, hogy ismerje a „küldött” a helyi fiókok",
+      "label": "Helyi személyazonosságok"
     },
     "message": "-",
+    "note": {
+      "refreshCacheRequired": "Ha megváltozik, akkor a gyorsítótárat újra kell építeni",
+      "reloadStatsPage": "Az opciók önműködően mentésre kerülnek. Bizonyos opcióváltozások nem alkalmazhatók önműködően a már megnyitott statisztikai oldalra vagy a meglévő gyorsítótár bejegyzésekre, ha a gyorsítótár aktiválva van. Megfelelő ikonokkal vannak jelölve.",
+      "reloadWindowRequired": "Ha megváltoztatja, a statisztika ablakot újra be kell tölteni",
+      "title": "Megjegyzés"
+    },
+    "ordinate": {
+      "description": "A függőleges tengely megjelenítése az összes vonalas és oszlopdiagramon",
+      "label": "Függőleges tengely"
+    },
+    "resetOptions": {
+      "description": "Állítsa vissza az összes beállítást az alapértelmezett értékre. A korábban megváltoztatott beállításoktól függően szükség lehet egy ablak vagy gyorsítótár frissítésére.",
+      "label": "Beállítások visszaállítása",
+      "removeIdentities": "Ez eltávolítja az összes helyi személyazonosságot, amelyet létrehozott. "
+    },
     "selfMessages": {
-      "label": "Üzenetek önmagamnak",
       "description": "Kizárja azokat az üzeneteket, amelyeket tőlem küldtem magamnak",
-      "values": {
-        "none": "Tiltva",
-        "sameAccount": "Csak ugyanaz a fiókot",
-        "anyAccount": "Bármely fiókból"
-      },
       "info": {
+        "anyAccount": "Azok az üzenetek, amelyekben a feladó és a fogadó azonosító, bármely fiókból kizárásra kerülnek",
         "none": "A magának küldött üzenetek átlagos üzenetként lesznek kezelve (alapértelmezett)",
-        "sameAccount": "Azok az üzenetek, amelyekben a feladó és a fogadó azonos fiók azonos fiókból, kizárásra kerülnek",
-        "anyAccount": "Azok az üzenetek, amelyekben a feladó és a fogadó azonosító, bármely fiókból kizárásra kerülnek"
+        "sameAccount": "Azok az üzenetek, amelyekben a feladó és a fogadó azonos fiók azonos fiókból, kizárásra kerülnek"
+      },
+      "label": "Üzenetek önmagamnak",
+      "values": {
+        "anyAccount": "Bármely fiókból",
+        "none": "Tiltva",
+        "sameAccount": "Csak ugyanaz a fiókot"
       }
     },
-    "leaderCount": {
-      "label": "Vezérszám",
-      "description": "A gyakori kapcsolattartókat felsoroló diagramokban szereplő bejegyzések száma (legfeljebb 999)"
+    "startOfWeek": {
+      "description": "A hét egyéni kezdete az összes hétköznapi diagramhoz",
+      "label": "Kezdje a hetet"
     },
-    "title": "Beállítások",
-    "resetOptions": {
-      "label": "Beállítások visszaállítása",
-      "description": "Állítsa vissza az összes beállítást az alapértelmezett értékre. A korábban megváltoztatott beállításoktól függően szükség lehet egy ablak vagy gyorsítótár frissítésére.",
-      "removeIdentities": "Ez eltávolítja az összes helyi személyazonosságot, amelyet létrehozott. "
-    }
+    "switch": {
+      "off": "Ki",
+      "on": "Be"
+    },
+    "title": "Beállítások"
+  },
+  "popup": {
+    "message": "-",
+    "nAccounts": "{0} fiók | {0} fiók",
+    "nFolders": "{0} mappa | {0} mappa",
+    "nMessages": "{0} üzenet | {0} üzenet",
+    "openAllStats": "Az összes statisztika megnyitása",
+    "openOptions": "Beállítások megnyitása"
+  },
+  "stats": {
+    "abbreviations": {
+      "calendarWeek": "h",
+      "day": "n",
+      "hour": "ó",
+      "minute": "p",
+      "quarter": "¼",
+      "second": "mp"
+    },
+    "account": "Fiók",
+    "accountEmpty": "Ez a postafiók üres, itt nincsenek e-mailek.",
+    "allAccounts": "Minden postafiók",
+    "charts": {
+      "contactsJunk": {
+        "description": "Levélszemétként megjelölt e-mailek száma küldőnként",
+        "title": "Levélszemétként megjelölve"
+      },
+      "contactsReceived": {
+        "description": "Feladónként kapott e-mailek száma",
+        "title": "A legtöbb kapott"
+      },
+      "contactsSent": {
+        "description": "A címzettenként elküldött e-mailek száma",
+        "title": "A legtöbbet elküldték"
+      },
+      "days": {
+        "description": "E-mailek száma dátum szerint",
+        "title": "Tevékenység itt: {0}"
+      },
+      "daytime": {
+        "description": "E-mailek száma napszakonként",
+        "title": "Nappal"
+      },
+      "foldersDistribution": {
+        "description": "E-mailek száma mappánként",
+        "title": "Mappák terjesztése"
+      },
+      "month": {
+        "description": "E-mailek száma az év hónapjában",
+        "title": "Hónap"
+      },
+      "months": {
+        "description": "E-mailek teljes száma havonta",
+        "title": "Hónapok"
+      },
+      "quarters": {
+        "description": "Az e-mailek száma negyedévenként",
+        "title": "Negyedek"
+      },
+      "temporalDistribution": {
+        "description": "Hétköznap / óra e-mailek száma",
+        "title": "Időbeli eloszlása"
+      },
+      "weekday": {
+        "description": "E-mailek száma a hét minden napján",
+        "title": "Hétköznap"
+      },
+      "weeks": {
+        "description": "Heti e-mailek teljes száma",
+        "title": "Hetek"
+      },
+      "years": {
+        "description": "Éves e-mailek teljes száma",
+        "title": "Évek"
+      }
+    },
+    "contact": "Névjegy",
+    "dataCollected": "{0} ezelőtt gyűjtött adatok",
+    "disclaimer": "A ThirdStats nem hivatkozik a megjelenített adatok helyességére.<br />Lehetséges problémák esetén kérjük <a href='{0}' target='_blank'>hozzon létre hibajelentést</a>.",
+    "folder": "Mappa",
+    "junkMails": "Levélszemetek",
+    "junkScore": "{0} levélszemét pontszám",
+    "loadingInProgress": "A fiók összes e-mailének betöltése folyamatban van…",
+    "mailsPerDay": "Levél naponta",
+    "mailsPerMonth": "Levél havonta",
+    "mailsReceived": "Levelek fogadva",
+    "mailsSent": "Levelek elküldve",
+    "mailsTotal": "Levelek összesen",
+    "mailsUnread": "Mails unread",
+    "mailsWeek": "levél/hét",
+    "mailsYear": "levél/év",
+    "message": "-",
+    "niceWork": "Szép munka!",
+    "nonEmptyFolders": "nem üres mappák | nem üres mappa | nem üres mappák",
+    "percentOfReceived": "A beérkezett adatok {0}%-a",
+    "percentOfTotal": "Az összes {0}%-a",
+    "starAndImprove": "Légy sztár, villálj a <a href='{0}' target='_blank'>GitHub</a>on.",
+    "timePeriod": "Dátumtartomány",
+    "tooltips": {
+      "clear": "Kijelölés törlése",
+      "comparison": "Fiókok összehasonlítása egy diagramban",
+      "comparisonWhenAccountsOption": "A fiókok összehasonlítása csak akkor érhető el, ha egynél több fiók engedélyezett a kiegészítő beállításokban",
+      "comparisonWhenFilter": "A fiókok összehasonlítása csak akkor érhető el, ha a fenti fiókszűrőben az „Összes fiók” van kiválasztva.",
+      "error": {
+        "dateFormat": "Formátum: ÉÉÉÉ-HH-NN szükséges, pl. 2020-01-31",
+        "dateOrderEnd": "A befejezés dátumának a kezdő dátum után kell lennie",
+        "dateOrderStart": "A kezdő dátumnak a befejezés dátuma előtt kell lennie",
+        "dateUnreal": "Érvényes dátumot kell megadni",
+        "empty": "Bevitel szükséges"
+      },
+      "expand": "Diagramterület kibontása",
+      "exportData": "Exportálja a jelenleg megjelenített adatokat JSON fájlként",
+      "folder": {
+        "notAvailable": "A(z) {0} mappák nem érhetők el"
+      },
+      "period": {
+        "end": "Dátumig\nTipp: A(z) „{0}” begépelése „{1}” lesz",
+        "start": "Dátumtól\nTipp: A(z) „{0}” begépelése „{1}” lesz"
+      },
+      "refresh": "Adatok frissítése",
+      "shrink": "Diagramterület csökkentése",
+      "sum": "Az összes fiók összegének megjelenítése"
+    },
+    "withinYears": "{0} éven belül"
   }
 }

--- a/public/_locales/it/messages.json
+++ b/public/_locales/it/messages.json
@@ -2,199 +2,201 @@
   "extensionDescription": {
     "message": "Uno splendido modo di visualizzare le statistiche per i tuoi account su Thunderbird"
   },
-  "popup": {
-    "account": "Account | Account",
-    "folder": "Cartella | Cartelle",
-    "message": "-",
-    "openAllStats": "Apri tutte le statistiche",
-    "openOptions": "Apri Opzioni",
-    "messages": "Messaggio | Messaggi"
-  },
-  "stats": {
-    "mailsTotal": "Mail totali",
-    "withinYears": "in {0} anni",
-    "mailsUnread": "Mail non lette",
-    "niceWork": "Ottimo lavoro!",
-    "percentOfReceived": "{0}% delle ricevute",
-    "mailsReceived": "Mail ricevute",
-    "percentOfTotal": "{0}% del totale",
-    "mailsSent": "Mail inviate",
-    "mailsPerMonth": "Mail al mese",
-    "mailsYear": "mail/anno",
-    "mailsPerDay": "Mail al giorno",
-    "mailsWeek": "mail/settimana",
-    "loadingInProgress": "Caricamento di tutte le email da questo account in corso…",
-    "accountEmpty": "Questo account è vuoto, non ci sono email qui.",
-    "timePeriod": "Periodo di tempo",
-    "charts": {
-      "years": {
-        "title": "Anni",
-        "description": "Numero di email all'anno"
-      },
-      "quarters": {
-        "title": "Trimestri",
-        "description": "Numero totale di email per trimestre"
-      },
-      "months": {
-        "title": "Mesi",
-        "description": "Numero di mail al mese"
-      },
-      "weeks": {
-        "title": "Settimane",
-        "description": "Numero totale di email per settimana"
-      },
-      "days": {
-        "title": "Attività in {0}",
-        "description": "Numero di email al giorno"
-      },
-      "daytime": {
-        "title": "Orari",
-        "description": "Numero di mail per orario del giorno"
-      },
-      "weekday": {
-        "title": "Giorni",
-        "description": "Numero di mail per giorno della settimana"
-      },
-      "month": {
-        "title": "Mesi",
-        "description": "Numero di mail al mese"
-      },
-      "temporalDistribution": {
-        "title": "Distribuzione temporale",
-        "description": "Numero di email per giorno della settimana e orario"
-      },
-      "contactsReceived": {
-        "title": "Più ricevute da",
-        "description": "Numero di email ricevute per indirizzo"
-      },
-      "contactsSent": {
-        "title": "Più inviate a",
-        "description": "Numero di email inviate per indirizzo"
-      },
-      "foldersDistribution": {
-        "description": "Numero di messaggi di posta elettronica per cartella",
-        "title": "Distribuzione delle cartelle"
-      },
-      "contactsJunk": {
-        "description": "Numero di messaggi di posta elettronica contrassegnati come Posta indesiderata per mittente",
-        "title": "Contrassegnato come spazzatura"
-      }
-    },
-    "tooltips": {
-      "expand": "Espandi area grafici",
-      "shrink": "Riduci area grafici",
-      "refresh": "Aggiorna i dati",
-      "clear": "Cancella selezione",
-      "period": {
-        "start": "Dalla data\nSuggerimento: digitando \"{0}\" diventa \"{1}\"",
-        "end": "Ad oggi\nSuggerimento: digitando \"{0}\" diventa \"{1}\""
-      },
-      "error": {
-        "empty": "È richiesto un ingresso",
-        "dateFormat": "Il formato AAAA-MM-GG è obbligatorio, ad es. 2020-01-31",
-        "dateUnreal": "È richiesta una data valida",
-        "dateOrderStart": "La data di inizio deve essere precedente alla data di fine",
-        "dateOrderEnd": "La data di fine deve essere successiva alla data di inizio"
-      },
-      "folder": {
-        "notAvailable": "Le cartelle non sono disponibili per {0}"
-      },
-      "comparison": "Confronta i conti in un grafico",
-      "sum": "Mostra la somma di tutti i conti",
-      "exportData": "Esporta i dati attualmente visualizzati come file JSON",
-      "comparisonWhenAccountsOption": "Il confronto dei conti è disponibile solo\nse più di un account è attivato nelle opzioni aggiuntive",
-      "comparisonWhenFilter": "Il confronto dei conti è disponibile solo\nse \"Tutti gli account\" è selezionato nel filtro degli account sopra"
-    },
-    "abbreviations": {
-      "calendarWeek": "W",
-      "quarter": "Q",
-      "day": "d",
-      "hour": "h",
-      "minute": "min",
-      "second": "s"
-    },
-    "starAndImprove": "Aggiungi una Stella e migliora questo progetto su <a href='{0}' target='_blank'>Github</a>",
-    "message": "-",
-    "dataCollected": "Dati raccolti {0} fa",
-    "allAccounts": "Tutti i account",
-    "nonEmptyFolders": "cartelle non vuote | cartella non vuota | cartelle non vuote",
-    "contact": "Contatto",
-    "disclaimer": "ThirdStats non rivendica la correttezza dei dati visualizzati.<br />In caso di possibili problemi, <a href='{0}' target='_blank'>crea una segnalazione di bug</a>.",
-    "junkMails": "Posta indesiderata",
-    "junkScore": "Punteggio spazzatura di {0}"
-  },
   "options": {
+    "activeAccounts": {
+      "color": "Assegna a ciascun account un colore personalizzato per distinguerli nella modalità di confronto.",
+      "description": "Abilita o disabilita gli account. Gli account disabilitati non verranno visualizzati in nessun elenco di account o statistiche.",
+      "label": "Account attivi",
+      "sumAndCompare": "L'attivazione di più di un account abilita l'opzione di filtro delle statistiche \"Tutti gli account\" per la visualizzazione della somma e del confronto."
+    },
+    "cache": {
+      "description": "Abilita il sistema di caching per una visualizzazione più rapida dei dati statistici già elaborati.",
+      "label": "Attiva la cache"
+    },
+    "clearCache": {
+      "description": "Rimuovi tutti i dati delle statistiche memorizzati nella cache da tutti gli account. Verrà ricostruito aprendo nuovamente la pagina delle statistiche.",
+      "empty": "La cache è vuota",
+      "label": "Cancella cache",
+      "size": "La dimensione della cache è {0}"
+    },
+    "darkMode": {
+      "description": "Passa dalla combinazione di colori chiari e scuri",
+      "label": "Modalità scura"
+    },
     "headings": {
       "appearance": "Aspetto ed Esperienza",
       "stats": "Grafici e Dati",
       "storage": "Archiviazione e Cache"
     },
-    "switch": {
-      "on": "On",
-      "off": "Off"
-    },
-    "darkMode": {
-      "label": "Modalità scura",
-      "description": "Passa dalla combinazione di colori chiari e scuri"
-    },
-    "ordinate": {
-      "label": "Asse verticale",
-      "description": "Visualizza l'asse verticale per tutti i grafici a linee ea barre"
+    "leaderCount": {
+      "description": "Numero di voci mostrate nei grafici che elencano i contatti frequenti (massimo 999)",
+      "label": "Conteggio leader"
     },
     "localIdentities": {
-      "label": "Identità locali",
-      "description": "Un elenco separato da virgole di indirizzi e-mail da riconoscere come 'inviati da' per gli account locali"
-    },
-    "startOfWeek": {
-      "label": "Inizia la settimana",
-      "description": "Inizio della settimana personalizzato per tutti i grafici relativi ai giorni feriali"
-    },
-    "activeAccounts": {
-      "label": "Account attivi",
-      "description": "Abilita o disabilita gli account. Gli account disabilitati non verranno visualizzati in nessun elenco di account o statistiche.",
-      "color": "Assegna a ciascun account un colore personalizzato per distinguerli nella modalità di confronto.",
-      "sumAndCompare": "L'attivazione di più di un account abilita l'opzione di filtro delle statistiche \"Tutti gli account\" per la visualizzazione della somma e del confronto."
-    },
-    "cache": {
-      "label": "Attiva la cache",
-      "description": "Abilita il sistema di caching per una visualizzazione più rapida dei dati statistici già elaborati."
-    },
-    "clearCache": {
-      "label": "Cancella cache",
-      "description": "Rimuovi tutti i dati delle statistiche memorizzati nella cache da tutti gli account. Verrà ricostruito aprendo nuovamente la pagina delle statistiche.",
-      "empty": "La cache è vuota",
-      "size": "La dimensione della cache è {0}"
-    },
-    "note": {
-      "title": "Nota",
-      "reloadStatsPage": "Le opzioni vengono salvate automaticamente. Se la pagina delle statistiche è già aperta, è necessario riaprirla o ricaricarla per applicare le modifiche.",
-      "reloadWindowRequired": "Se modificata, la finestra delle statistiche deve essere ricaricata",
-      "refreshCacheRequired": "Se modificata, la cache deve essere ricostruita"
+      "description": "Un elenco separato da virgole di indirizzi e-mail da riconoscere come 'inviati da' per gli account locali",
+      "label": "Identità locali"
     },
     "message": "-",
+    "note": {
+      "refreshCacheRequired": "Se modificata, la cache deve essere ricostruita",
+      "reloadStatsPage": "Le opzioni vengono salvate automaticamente. Se la pagina delle statistiche è già aperta, è necessario riaprirla o ricaricarla per applicare le modifiche.",
+      "reloadWindowRequired": "Se modificata, la finestra delle statistiche deve essere ricaricata",
+      "title": "Nota"
+    },
+    "ordinate": {
+      "description": "Visualizza l'asse verticale per tutti i grafici a linee ea barre",
+      "label": "Asse verticale"
+    },
+    "resetOptions": {
+      "description": "Resettare tutte le opzioni ai valori predefiniti.",
+      "label": "Resettare le opzioni",
+      "removeIdentities": "Ciò rimuoverà anche tutte le identità locali che hai creato."
+    },
     "selfMessages": {
-      "label": "Messaggi personali",
       "description": "Escludi i messaggi che sono stati inviati da me a me stesso",
-      "values": {
-        "none": "Disattivato",
-        "sameAccount": "Solo lo stesso account",
-        "anyAccount": "Da qualsiasi account"
-      },
       "info": {
+        "anyAccount": "I messaggi in cui mittente e destinatario sono identità di qualsiasi account verranno esclusi",
         "none": "I messaggi personali verranno inclusi e trattati come normali e-mail (impostazione predefinita)",
-        "sameAccount": "I messaggi in cui mittente e destinatario sono identità dello stesso account verranno esclusi",
-        "anyAccount": "I messaggi in cui mittente e destinatario sono identità di qualsiasi account verranno esclusi"
+        "sameAccount": "I messaggi in cui mittente e destinatario sono identità dello stesso account verranno esclusi"
+      },
+      "label": "Messaggi personali",
+      "values": {
+        "anyAccount": "Da qualsiasi account",
+        "none": "Disattivato",
+        "sameAccount": "Solo lo stesso account"
       }
     },
-    "leaderCount": {
-      "label": "Conteggio leader",
-      "description": "Numero di voci mostrate nei grafici che elencano i contatti frequenti (massimo 999)"
+    "startOfWeek": {
+      "description": "Inizio della settimana personalizzato per tutti i grafici relativi ai giorni feriali",
+      "label": "Inizia la settimana"
     },
-    "title": "Opzioni",
-    "resetOptions": {
-      "label": "Resettare le opzioni",
-      "description": "Resettare tutte le opzioni ai valori predefiniti.",
-      "removeIdentities": "Ciò rimuoverà anche tutte le identità locali che hai creato."
-    }
+    "switch": {
+      "off": "Off",
+      "on": "On"
+    },
+    "title": "Opzioni"
+  },
+  "popup": {
+    "message": "-",
+    "nAccounts": "{0} Account | {0} Account",
+    "nFolders": "{0} Cartella | {0} Cartelle",
+    "nMessages": "{0} Messaggio | {0} Messaggi",
+    "openAllStats": "Apri tutte le statistiche",
+    "openOptions": "Apri Opzioni"
+  },
+  "stats": {
+    "abbreviations": {
+      "calendarWeek": "W",
+      "day": "d",
+      "hour": "h",
+      "minute": "min",
+      "quarter": "Q",
+      "second": "s"
+    },
+    "account": "Account",
+    "accountEmpty": "Questo account è vuoto, non ci sono email qui.",
+    "allAccounts": "Tutti i account",
+    "charts": {
+      "contactsJunk": {
+        "description": "Numero di messaggi di posta elettronica contrassegnati come Posta indesiderata per mittente",
+        "title": "Contrassegnato come spazzatura"
+      },
+      "contactsReceived": {
+        "description": "Numero di email ricevute per indirizzo",
+        "title": "Più ricevute da"
+      },
+      "contactsSent": {
+        "description": "Numero di email inviate per indirizzo",
+        "title": "Più inviate a"
+      },
+      "days": {
+        "description": "Numero di email al giorno",
+        "title": "Attività in {0}"
+      },
+      "daytime": {
+        "description": "Numero di mail per orario del giorno",
+        "title": "Orari"
+      },
+      "foldersDistribution": {
+        "description": "Numero di messaggi di posta elettronica per cartella",
+        "title": "Distribuzione delle cartelle"
+      },
+      "month": {
+        "description": "Numero di mail al mese",
+        "title": "Mesi"
+      },
+      "months": {
+        "description": "Numero di mail al mese",
+        "title": "Mesi"
+      },
+      "quarters": {
+        "description": "Numero totale di email per trimestre",
+        "title": "Trimestri"
+      },
+      "temporalDistribution": {
+        "description": "Numero di email per giorno della settimana e orario",
+        "title": "Distribuzione temporale"
+      },
+      "weekday": {
+        "description": "Numero di mail per giorno della settimana",
+        "title": "Giorni"
+      },
+      "weeks": {
+        "description": "Numero totale di email per settimana",
+        "title": "Settimane"
+      },
+      "years": {
+        "description": "Numero di email all'anno",
+        "title": "Anni"
+      }
+    },
+    "contact": "Contatto",
+    "dataCollected": "Dati raccolti {0} fa",
+    "disclaimer": "ThirdStats non rivendica la correttezza dei dati visualizzati.<br />In caso di possibili problemi, <a href='{0}' target='_blank'>crea una segnalazione di bug</a>.",
+    "folder": "Cartella",
+    "junkMails": "Posta indesiderata",
+    "junkScore": "Punteggio spazzatura di {0}",
+    "loadingInProgress": "Caricamento di tutte le email da questo account in corso…",
+    "mailsPerDay": "Mail al giorno",
+    "mailsPerMonth": "Mail al mese",
+    "mailsReceived": "Mail ricevute",
+    "mailsSent": "Mail inviate",
+    "mailsTotal": "Mail totali",
+    "mailsUnread": "Mail non lette",
+    "mailsWeek": "mail/settimana",
+    "mailsYear": "mail/anno",
+    "message": "-",
+    "niceWork": "Ottimo lavoro!",
+    "nonEmptyFolders": "cartelle non vuote | cartella non vuota | cartelle non vuote",
+    "percentOfReceived": "{0}% delle ricevute",
+    "percentOfTotal": "{0}% del totale",
+    "starAndImprove": "Aggiungi una Stella e migliora questo progetto su <a href='{0}' target='_blank'>Github</a>",
+    "timePeriod": "Periodo di tempo",
+    "tooltips": {
+      "clear": "Cancella selezione",
+      "comparison": "Confronta i conti in un grafico",
+      "comparisonWhenAccountsOption": "Il confronto dei conti è disponibile solo\nse più di un account è attivato nelle opzioni aggiuntive",
+      "comparisonWhenFilter": "Il confronto dei conti è disponibile solo\nse \"Tutti gli account\" è selezionato nel filtro degli account sopra",
+      "error": {
+        "dateFormat": "Il formato AAAA-MM-GG è obbligatorio, ad es. 2020-01-31",
+        "dateOrderEnd": "La data di fine deve essere successiva alla data di inizio",
+        "dateOrderStart": "La data di inizio deve essere precedente alla data di fine",
+        "dateUnreal": "È richiesta una data valida",
+        "empty": "È richiesto un ingresso"
+      },
+      "expand": "Espandi area grafici",
+      "exportData": "Esporta i dati attualmente visualizzati come file JSON",
+      "folder": {
+        "notAvailable": "Le cartelle non sono disponibili per {0}"
+      },
+      "period": {
+        "end": "Ad oggi\nSuggerimento: digitando \"{0}\" diventa \"{1}\"",
+        "start": "Dalla data\nSuggerimento: digitando \"{0}\" diventa \"{1}\""
+      },
+      "refresh": "Aggiorna i dati",
+      "shrink": "Riduci area grafici",
+      "sum": "Mostra la somma di tutti i conti"
+    },
+    "withinYears": "in {0} anni"
   }
 }

--- a/public/_locales/ja/messages.json
+++ b/public/_locales/ja/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "アカウント | アカウント",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0}アカウント | {0}アカウント"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "曜日",
       "quarter": "四半期"
     },
+    "account": "アカウント",
     "accountEmpty": "このアカウントにはメールはありません。",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/pl/messages.json
+++ b/public/_locales/pl/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "Konto | Konta",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} Konto | {0} Konta"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "TK",
       "quarter": "Ć"
     },
+    "account": "Konto",
     "accountEmpty": "To konto jest puste, nie ma żadnych e-maili.",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/pt/messages.json
+++ b/public/_locales/pt/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "Conta | Contas",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} Conta | {0} Contas"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "S",
       "quarter": "T"
     },
+    "account": "Conta",
     "accountEmpty": "Essa conta está vazia, sem e-mails aqui.",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/ru/messages.json
+++ b/public/_locales/ru/messages.json
@@ -68,10 +68,10 @@
     "title": "Настройки"
   },
   "popup": {
-    "account": "Аккаунт | Аккаунты",
-    "folder": "Папка | Папки",
     "message": "-",
-    "messages": "Письмо | Письма",
+    "nAccounts": "{0} Аккаунт | {0} Аккаунты",
+    "nFolders": "{0} Папка | {0} Папки",
+    "nMessages": "{0} Письмо | {0} Письма",
     "openAllStats": "Открыть всю статистику",
     "openOptions": "Открыть Настройки"
   },
@@ -84,6 +84,7 @@
       "quarter": "К",
       "second": "с"
     },
+    "account": "Аккаунт",
     "accountEmpty": "Пустой аккаунт, писем нет.",
     "allAccounts": "Все Аккаунты",
     "charts": {
@@ -133,6 +134,7 @@
       }
     },
     "dataCollected": "Данные посчитаны {0} назад",
+    "folder": "Папка",
     "loadingInProgress": "Идет обработка писем…",
     "mailsPerDay": "Писем за день",
     "mailsPerMonth": "Писем за месяц",

--- a/public/_locales/sv/messages.json
+++ b/public/_locales/sv/messages.json
@@ -2,190 +2,192 @@
   "extensionDescription": {
     "message": "Vackert visualiserad statistik för dina E-postkonton i Thunderbird"
   },
-  "popup": {
-    "account": "Konto | Konton",
-    "folder": "Mapp | Mappar",
-    "message": "-",
-    "openAllStats": "Öppna all Statistik",
-    "openOptions": "Öppna Alternativ",
-    "messages": "Meddelande | Meddelanden"
-  },
-  "stats": {
-    "mailsTotal": "Antal mejl",
-    "withinYears": "inom {0} år",
-    "mailsUnread": "Olästa mejl",
-    "niceWork": "Bra jobbat!",
-    "percentOfReceived": "{0}% av mottagna",
-    "mailsReceived": "Mottagna mejl",
-    "percentOfTotal": "{0}% av totalen",
-    "mailsSent": "Skickade mejl",
-    "mailsPerMonth": "Mejl per månad",
-    "mailsYear": "mejl/år",
-    "mailsPerDay": "Mejl per dag",
-    "mailsWeek": "mejl/vecka",
-    "loadingInProgress": "Inläsning av alla mejl från detta konto pågår…",
-    "accountEmpty": "Detta konto är tomt, inga mejl hittas.",
-    "timePeriod": "Tidsperiod",
-    "charts": {
-      "years": {
-        "title": "År",
-        "description": "Totala antalet mejl per år"
-      },
-      "quarters": {
-        "title": "Kvartal",
-        "description": "Totalt antal mejl per kvartal"
-      },
-      "months": {
-        "title": "Månader",
-        "description": "Totala antalet mejl per månad"
-      },
-      "weeks": {
-        "title": "Veckor",
-        "description": "Totala antalet mejl per vecka"
-      },
-      "days": {
-        "title": "Aktivitet under {0}",
-        "description": "Antal mejl per dag"
-      },
-      "daytime": {
-        "title": "Dag",
-        "description": "Antal mejl per tid på dagen"
-      },
-      "weekday": {
-        "title": "Veckodag",
-        "description": "Antal mejl per dag på veckan"
-      },
-      "month": {
-        "title": "Månad",
-        "description": "Antal mejl per månad på året"
-      },
-      "temporalDistribution": {
-        "title": "Timlig fördelning",
-        "description": "Antal mejl per veckodag per timme"
-      },
-      "contactsReceived": {
-        "title": "Mest mottaget från",
-        "description": "Antal mejl skickade per mottagare"
-      },
-      "contactsSent": {
-        "title": "Mest skickat till",
-        "description": "Antal mejl mottagna per avsändare"
-      },
-      "foldersDistribution": {
-        "description": "Antal e-postmeddelanden per mapp",
-        "title": "Mappdistribution"
-      }
-    },
-    "tooltips": {
-      "expand": "Expandera diagramområdet",
-      "shrink": "Krymp diagramområdet",
-      "refresh": "Uppdatera data",
-      "clear": "Rensa urval",
-      "period": {
-        "start": "Från Datum\nTips: Skriver du '{0}' blir det '{1}'",
-        "end": "Till Datum\nTips: Skriver du '{0}' blir det '{1}'"
-      },
-      "error": {
-        "empty": "Indata krävs",
-        "dateFormat": "Format YYYY-MM-DD krävs, e.g. 2020-01-31",
-        "dateUnreal": "Ett giltigt datum krävs",
-        "dateOrderStart": "Startdatum måste vara före slutdatum",
-        "dateOrderEnd": "Slutdatum måste vara efter startdatum"
-      },
-      "folder": {
-        "notAvailable": "Mappar är inte tillgängliga för {0}"
-      },
-      "comparison": "Jämför konton i ett diagram",
-      "sum": "Visa summan av alla konton",
-      "exportData": "Exportera för närvarande visad data som JSON-fil"
-    },
-    "abbreviations": {
-      "calendarWeek": "V",
-      "quarter": "K",
-      "day": "d",
-      "hour": "t",
-      "minute": "min",
-      "second": "s"
-    },
-    "starAndImprove": "Ge en 'Stjärna' och förbättra detta projekt på <a href='{0}' target='_blank'>Github</a>",
-    "message": "-",
-    "dataCollected": "Data samlad {0} sen",
-    "allAccounts": "Alla Konton",
-    "nonEmptyFolders": "icke-tomma mappar | icke-tom mapp | icke-tomma mappar",
-    "contact": "Kontakt",
-    "disclaimer": "ThirdStats gör inget anspråk för korrektheten på de uppgifter som visas. <br /> Vid eventuella problem, <a href='{0}' target='_blank'> skapa en felrapport </a>."
-  },
   "options": {
+    "activeAccounts": {
+      "color": "Ge varje konto en anpassad färg för att skilja mellan dem i jämförelseläge.",
+      "description": "Aktivera eller inaktivera konton. Inaktiverade konton visas inte i kontolistor eller statistik.",
+      "label": "Aktiva Konton"
+    },
+    "cache": {
+      "description": "Aktivera cachingsystem för snabbare visning av redan bearbetad statistikdata.",
+      "label": "Aktivera Cache"
+    },
+    "clearCache": {
+      "description": "Ta bort all cachad statistikdata från alla konton. Kommer att återbyggas när statistiksidan öppnas igen.",
+      "empty": "Cache är tom",
+      "label": "Rensa Cache",
+      "size": "Cachestorlek är {0}"
+    },
+    "darkMode": {
+      "description": "Växla mellan mörkt och ljust färgschema",
+      "label": "Mörkt Läge"
+    },
     "headings": {
       "appearance": "Utseende & Erfarenhet",
       "stats": "Diagram & Data",
       "storage": "Lagring & Cache"
     },
-    "switch": {
-      "on": "På",
-      "off": "Av"
-    },
-    "darkMode": {
-      "label": "Mörkt Läge",
-      "description": "Växla mellan mörkt och ljust färgschema"
-    },
-    "ordinate": {
-      "label": "Vertikalaxel",
-      "description": "Visa vertikalaxel för alla linje- och stapeldiagram"
+    "leaderCount": {
+      "description": "Antal poster som visas i diagram som visar frekventa kontakter (maximalt 999)",
+      "label": "Ledarräkning"
     },
     "localIdentities": {
-      "label": "Lokala Identiteter",
-      "description": "En kommaseparerad lista med mejladresser att känna igen som 'skickat från' för lokala konton"
-    },
-    "startOfWeek": {
-      "label": "Starta Veckan på",
-      "description": "Anpassad start av vecka för alla veckodagsrelaterade diagram"
-    },
-    "activeAccounts": {
-      "label": "Aktiva Konton",
-      "description": "Aktivera eller inaktivera konton. Inaktiverade konton visas inte i kontolistor eller statistik.",
-      "color": "Ge varje konto en anpassad färg för att skilja mellan dem i jämförelseläge."
-    },
-    "cache": {
-      "label": "Aktivera Cache",
-      "description": "Aktivera cachingsystem för snabbare visning av redan bearbetad statistikdata."
-    },
-    "clearCache": {
-      "label": "Rensa Cache",
-      "description": "Ta bort all cachad statistikdata från alla konton. Kommer att återbyggas när statistiksidan öppnas igen.",
-      "empty": "Cache är tom",
-      "size": "Cachestorlek är {0}"
-    },
-    "note": {
-      "title": "Notering",
-      "reloadStatsPage": "Alternativ sparas automatiskt. Om statistiksidan redan är öppen måste du öppna den igen eller ladda om den för att ändringar ska kunna tillämpas. För vissa alternativ är det också nödvändigt att uppdatera cachad data om cache är aktiverat.",
-      "reloadWindowRequired": "Om ändrat, måste statistikfönstret laddas om",
-      "refreshCacheRequired": "Om ändrat, måste cachen byggas om"
+      "description": "En kommaseparerad lista med mejladresser att känna igen som 'skickat från' för lokala konton",
+      "label": "Lokala Identiteter"
     },
     "message": "-",
+    "note": {
+      "refreshCacheRequired": "Om ändrat, måste cachen byggas om",
+      "reloadStatsPage": "Alternativ sparas automatiskt. Om statistiksidan redan är öppen måste du öppna den igen eller ladda om den för att ändringar ska kunna tillämpas. För vissa alternativ är det också nödvändigt att uppdatera cachad data om cache är aktiverat.",
+      "reloadWindowRequired": "Om ändrat, måste statistikfönstret laddas om",
+      "title": "Notering"
+    },
+    "ordinate": {
+      "description": "Visa vertikalaxel för alla linje- och stapeldiagram",
+      "label": "Vertikalaxel"
+    },
+    "resetOptions": {
+      "description": "Återställ alla alternativ till standardvärdena. Beroende på vilka alternativ du har ändrat tidigare kan en fönster eller cache-uppdatering krävas.",
+      "label": "Återställ alternativ",
+      "removeIdentities": "Detta tar också bort alla lokala identiteter du skapat."
+    },
     "selfMessages": {
-      "label": "Självmeddelanden",
       "description": "Exkludera meddelanden som var skickade från mig till mig själv",
-      "values": {
-        "none": "Inaktiverad",
-        "sameAccount": "Samma Konto Bara",
-        "anyAccount": "Från Alla Konton"
-      },
       "info": {
+        "anyAccount": "Meddelanden där avsändare och mottagare är identiteter från alla konton kommer bli exkluderade",
         "none": "Självmeddelanden kommer inkluderas och behandlas som normala mejl (standard)",
-        "sameAccount": "Meddelanden där avsändare och mottagare är identiteter från samma konto kommer bli exkluderade",
-        "anyAccount": "Meddelanden där avsändare och mottagare är identiteter från alla konton kommer bli exkluderade"
+        "sameAccount": "Meddelanden där avsändare och mottagare är identiteter från samma konto kommer bli exkluderade"
+      },
+      "label": "Självmeddelanden",
+      "values": {
+        "anyAccount": "Från Alla Konton",
+        "none": "Inaktiverad",
+        "sameAccount": "Samma Konto Bara"
       }
     },
-    "leaderCount": {
-      "label": "Ledarräkning",
-      "description": "Antal poster som visas i diagram som visar frekventa kontakter (maximalt 999)"
+    "startOfWeek": {
+      "description": "Anpassad start av vecka för alla veckodagsrelaterade diagram",
+      "label": "Starta Veckan på"
     },
-    "title": "Alternativ",
-    "resetOptions": {
-      "label": "Återställ alternativ",
-      "description": "Återställ alla alternativ till standardvärdena. Beroende på vilka alternativ du har ändrat tidigare kan en fönster eller cache-uppdatering krävas.",
-      "removeIdentities": "Detta tar också bort alla lokala identiteter du skapat."
-    }
+    "switch": {
+      "off": "Av",
+      "on": "På"
+    },
+    "title": "Alternativ"
+  },
+  "popup": {
+    "message": "-",
+    "nAccounts": "{0} Konto | {0} Konton",
+    "nFolders": "{0} Mapp | {0} Mappar",
+    "nMessages": "{0} Meddelande | {0} Meddelanden",
+    "openAllStats": "Öppna all Statistik",
+    "openOptions": "Öppna Alternativ"
+  },
+  "stats": {
+    "abbreviations": {
+      "calendarWeek": "V",
+      "day": "d",
+      "hour": "t",
+      "minute": "min",
+      "quarter": "K",
+      "second": "s"
+    },
+    "account": "Konto",
+    "accountEmpty": "Detta konto är tomt, inga mejl hittas.",
+    "allAccounts": "Alla Konton",
+    "charts": {
+      "contactsReceived": {
+        "description": "Antal mejl skickade per mottagare",
+        "title": "Mest mottaget från"
+      },
+      "contactsSent": {
+        "description": "Antal mejl mottagna per avsändare",
+        "title": "Mest skickat till"
+      },
+      "days": {
+        "description": "Antal mejl per dag",
+        "title": "Aktivitet under {0}"
+      },
+      "daytime": {
+        "description": "Antal mejl per tid på dagen",
+        "title": "Dag"
+      },
+      "foldersDistribution": {
+        "description": "Antal e-postmeddelanden per mapp",
+        "title": "Mappdistribution"
+      },
+      "month": {
+        "description": "Antal mejl per månad på året",
+        "title": "Månad"
+      },
+      "months": {
+        "description": "Totala antalet mejl per månad",
+        "title": "Månader"
+      },
+      "quarters": {
+        "description": "Totalt antal mejl per kvartal",
+        "title": "Kvartal"
+      },
+      "temporalDistribution": {
+        "description": "Antal mejl per veckodag per timme",
+        "title": "Timlig fördelning"
+      },
+      "weekday": {
+        "description": "Antal mejl per dag på veckan",
+        "title": "Veckodag"
+      },
+      "weeks": {
+        "description": "Totala antalet mejl per vecka",
+        "title": "Veckor"
+      },
+      "years": {
+        "description": "Totala antalet mejl per år",
+        "title": "År"
+      }
+    },
+    "contact": "Kontakt",
+    "dataCollected": "Data samlad {0} sen",
+    "disclaimer": "ThirdStats gör inget anspråk för korrektheten på de uppgifter som visas. <br /> Vid eventuella problem, <a href='{0}' target='_blank'> skapa en felrapport </a>.",
+    "folder": "Mapp",
+    "loadingInProgress": "Inläsning av alla mejl från detta konto pågår…",
+    "mailsPerDay": "Mejl per dag",
+    "mailsPerMonth": "Mejl per månad",
+    "mailsReceived": "Mottagna mejl",
+    "mailsSent": "Skickade mejl",
+    "mailsTotal": "Antal mejl",
+    "mailsUnread": "Olästa mejl",
+    "mailsWeek": "mejl/vecka",
+    "mailsYear": "mejl/år",
+    "message": "-",
+    "niceWork": "Bra jobbat!",
+    "nonEmptyFolders": "icke-tomma mappar | icke-tom mapp | icke-tomma mappar",
+    "percentOfReceived": "{0}% av mottagna",
+    "percentOfTotal": "{0}% av totalen",
+    "starAndImprove": "Ge en 'Stjärna' och förbättra detta projekt på <a href='{0}' target='_blank'>Github</a>",
+    "timePeriod": "Tidsperiod",
+    "tooltips": {
+      "clear": "Rensa urval",
+      "comparison": "Jämför konton i ett diagram",
+      "error": {
+        "dateFormat": "Format YYYY-MM-DD krävs, e.g. 2020-01-31",
+        "dateOrderEnd": "Slutdatum måste vara efter startdatum",
+        "dateOrderStart": "Startdatum måste vara före slutdatum",
+        "dateUnreal": "Ett giltigt datum krävs",
+        "empty": "Indata krävs"
+      },
+      "expand": "Expandera diagramområdet",
+      "exportData": "Exportera för närvarande visad data som JSON-fil",
+      "folder": {
+        "notAvailable": "Mappar är inte tillgängliga för {0}"
+      },
+      "period": {
+        "end": "Till Datum\nTips: Skriver du '{0}' blir det '{1}'",
+        "start": "Från Datum\nTips: Skriver du '{0}' blir det '{1}'"
+      },
+      "refresh": "Uppdatera data",
+      "shrink": "Krymp diagramområdet",
+      "sum": "Visa summan av alla konton"
+    },
+    "withinYears": "inom {0} år"
   }
 }

--- a/public/_locales/th/messages.json
+++ b/public/_locales/th/messages.json
@@ -6,10 +6,11 @@
     "message": "-"
   },
   "popup": {
-    "account": "บัญชีผู้ใช้ | บัญชี",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} บัญชีผู้ใช้ | {0} บัญชี"
   },
   "stats": {
+    "account": "บัญชีผู้ใช้",
     "accountEmpty": "บัญชีนี้ว่างเปล่า ไม่พบอีเมล",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/tr/messages.json
+++ b/public/_locales/tr/messages.json
@@ -18,14 +18,15 @@
     }
   },
   "popup": {
-    "account": "Hesap | Hesaplar",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} Hesap | {0} Hesaplar"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "H",
       "quarter": "Ç"
     },
+    "account": "Hesap",
     "accountEmpty": "Bu hesap boş, e-posta yok.",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/zh-cn/messages.json
+++ b/public/_locales/zh-cn/messages.json
@@ -41,14 +41,15 @@
     }
   },
   "popup": {
-    "account": "账号 | 账号",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "账号 {0} | 账号 {0}"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "周",
       "quarter": "季"
     },
+    "account": "账号",
     "accountEmpty": "此账号为空，没有邮件。",
     "charts": {
       "contactsReceived": {

--- a/public/_locales/zh-tw/messages.json
+++ b/public/_locales/zh-tw/messages.json
@@ -49,15 +49,16 @@
     }
   },
   "popup": {
-    "account": "帳號 | 帳號",
-    "folder": "文件夾 | 文件夾",
-    "message": "-"
+    "message": "-",
+    "nAccounts": "{0} 帳號 | {0} 帳號",
+    "nFolders": "{0} 文件夾 | {0} 文件夾"
   },
   "stats": {
     "abbreviations": {
       "calendarWeek": "週",
       "quarter": "季"
     },
+    "account": "帳號",
     "accountEmpty": "當前帳號為空，並沒有任何郵件。",
     "allAccountsSum": "所有帳號（總和）",
     "charts": {
@@ -106,6 +107,7 @@
         "title": "年"
       }
     },
+    "folder": "文件夾",
     "loadingInProgress": "正在讀取當前帳號的所有電子郵件……",
     "mailsPerDay": "每日郵件",
     "mailsPerMonth": "每月郵件",

--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -4,7 +4,7 @@
 			<!-- header containing number of accounts and linking to stats page -->
 			<header class="d-flex gap-0-5 mb-1-5">
 				<h3 class="flex-grow">
-					<span class="mr-1">{{ accounts.length }} {{ $tc("popup.account", accounts.length) }}</span>
+					<span class="mr-1">{{ $tc("popup.nAccounts", accounts.length, [accounts.length]) }}</span>
 					<span v-if="loading" class="dark loading"></span>
 				</h3>
 				<div
@@ -41,8 +41,8 @@
 					<div class="position-relative z-5">
 						<h4>{{ a.name }}</h4>
 						<div class="text-small text-secondary">
-							{{ a.folderCount }} {{ $tc("popup.folder", a.folderCount) }}
-							<div v-if="a.hasOwnProperty('messageCount')">{{ a.messageCount }} {{ $tc("popup.messages", a.messageCount) }}</div>
+							{{ $tc("popup.nFolders", a.folderCount, [a.folderCount]) }}
+							<div v-if="a.hasOwnProperty('messageCount')">{{ $tc("popup.nMessages", a.messageCount, [a.messageCount]) }}</div>
 						</div>
 					</div>
 					<LineChart

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -20,7 +20,7 @@
 				<div class="filter d-flex flex-wrap gap-1">
 					<!-- account selection -->
 					<div class="filter-account d-flex">
-						<label for="account" class="align-center text-gray p-0-5">{{ $tc("popup.account", 1) }}</label>
+						<label for="account" class="align-center text-gray p-0-5">{{ $t("stats.account") }}</label>
 						<select v-model="active.account" :disabled="loading" class="align-stretch w-6" :class="{ disabled: loading }" id="account">
 							<option v-if="accounts.length > 1 && preferences.cache" :value="'sum'">{{ $t("stats.allAccounts") }}</option>
 							<option v-else disabled>{{ $t("stats.allAccounts") }}</option>
@@ -46,7 +46,7 @@
 					</div>
 					<!-- folder selection -->
 					<div class="filter-folder d-flex">
-						<label for="folder" class="align-center text-gray p-0-5">{{ $tc("popup.folder", 1) }}</label>
+						<label for="folder" class="align-center text-gray p-0-5">{{ $t("stats.folder") }}</label>
 						<div
 							class="d-flex align-stretch tooltip-bottom"
 							:class="{ tooltip: !singleAccount }"


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Popup language keys were improved by including amount numbers.

## Benefits

This reduces the use of the same translation in different contexts and provides the possibility to place the number as it suits the corresponding translation.

## Applicable Issues

#295 
