### PR TITLE
Tags analysis

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -133,6 +133,10 @@
         "description": "Total number of emails per quarter",
         "title": "Quarters"
       },
+      "tagsCount": {
+        "description": "Total number of emails per tag",
+        "title": "Tags"
+      },
       "temporalDistribution": {
         "description": "Number of emails per weekday per hour",
         "title": "Temporal distribution"
@@ -159,6 +163,7 @@
     "loadingInProgress": "Loading of all emails from this account in progress…",
     "mailsPerDay": "Mails per day",
     "mailsPerMonth": "Mails per month",
+    "mailsPerTag": "Mails per tag",
     "mailsReceived": "Mails received",
     "mailsSent": "Mails sent",
     "mailsTotal": "Mails total",

--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -74,6 +74,10 @@
       "off": "Off",
       "on": "On"
     },
+    "tagColors": {
+      "description": "Draw charts about tags using corresponding tag colors",
+      "label": "Tag Colors"
+    },
     "title": "Options"
   },
   "popup": {

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -48,6 +48,20 @@
 						</label>
 					</div>
 				</div>
+				<!-- option: tag colors -->
+				<div class="entry">
+					<label for="tagColors">
+						{{ $t("options.tagColors.label") }}
+						<span class="d-block text-gray text-small">{{ $t("options.tagColors.description") }}</span>
+					</label>
+					<div class="action d-flex">
+						<label class="switch">
+							<input type="checkbox" id="tagColors" v-model="options.tagColors" />
+							<span class="switch-label" :data-on="$t('options.switch.on')" :data-off="$t('options.switch.off')"></span> 
+							<span class="switch-handle"></span> 
+						</label>
+					</div>
+				</div>
 			</section>
 			<!-- section related to charts and data retrieval -->
 			<section class="mb-3">
@@ -348,6 +362,7 @@ export default {
 		optionsObject (
 			dark = false,
 			ordinate = true,
+			tagColors = false,
 			startOfWeek = -1,
 			addresses = "",
 			accounts = [],
@@ -363,6 +378,7 @@ export default {
 				options: {
 					dark: dark === null ? this.options.dark : dark,
 					ordinate: ordinate === null ? this.options.ordinate : ordinate,
+					tagColors: tagColors === null ? this.options.tagColors : tagColors,
 					startOfWeek: startOfWeek === null ? this.options.startOfWeek : startOfWeek,
 					addresses: addresses === null ? this.options.addresses : addresses,
 					accounts: accounts === null ? this.options.accounts : accounts,

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -652,6 +652,34 @@
 							/>
 						</div>
 					</div>
+					<!-- section: tags -->
+					<div class="tab-area" v-if="display.tags">
+						<ul class="tab">
+							<li
+								v-for="(active, label) in tabs.tags"
+								:key="label"
+								class="tab-item cursor-default tooltip tooltip-bottom"
+								:data-tooltip="$t('stats.charts.' + label + '.description')"
+								:class="{ 'active': active, 'cursor-pointer': !active, 'text-hover-accent2': !active }"
+								@click="activateTab('tags', label)"
+							>
+								<span
+									class="transition-color transition-border-color border-bottom-accent3"
+								>
+									{{ $t("stats.charts." + label + ".title") }}
+								</span>
+							</li>
+						</ul>
+						<div class="tab-content mt-1">
+							<!-- tags count -->
+							<BarChart
+								v-if="tabs.tags.tagsCount"
+								:datasets="tagsChartData.datasets"
+								:labels="tagsChartData.labels"
+								:horizontal="true"
+							/>
+						</div>
+					</div>
 				</div>
 			</section>
 			<!-- footer -->
@@ -769,6 +797,7 @@ export default {
 			identities: [],  // list of all existing identities
 			folders: [],     // list of all existing folders for the current account selection
 			contacts: [],    // list of all existing contacts for contact filter
+			tags: [],        // list of all existing tags
 			active: {
 				account: null, // currently selected account
 				folder: null,  // currently selected folder
@@ -817,6 +846,9 @@ export default {
 				folders: {
 					foldersDistribution: true,
 				},
+				tags: {
+					tagsCount: true,
+				}
 			},
 			preferences: {   // preferences set for this page
 				sections: {    // preferences that can be set on this page
@@ -854,6 +886,8 @@ export default {
 		this.addStorageListener()
 		// get stored options
 		await this.getOptions()
+		// retrieve all tags
+		await this.getTags()
 		// retrieve all accounts
 		await this.getAccounts()
 	},
@@ -920,6 +954,7 @@ export default {
 					received: {},
 					sent: {},
 				},
+				tags: {},
 			}
 		},
 		// basic data structure to display charts
@@ -999,6 +1034,11 @@ export default {
 			const id = (new URLSearchParams(uri)).get("s")
 			if (!id || (id == "sum" && !this.preferences.cache) || (id == "sum" && accounts.length <= 1)) id = accounts[0].id
 			this.active.account = id
+		},
+		// retrieve list of tags that can be set on messages
+		// their human-friendly name, color, and sort order
+		async getTags () {
+			this.tags = await messenger.messages.listTags();
 		},
 		// analyze folders of a given account <a>
 		// return processed data oject structured like initData
@@ -1166,6 +1206,14 @@ export default {
 			} else {
 				data.folders[type][f]++
 			}
+			// tags
+			m.tags.forEach(t => {
+				if (!(tag in data.tags)) {
+					data.tags[tag] = 1
+				} else {
+					data.tags[tag]++
+				}
+			})
 		},
 		// check if a contact is involved in a message
 		// = <contact> is either author or recipient, CC or BCC of <message>
@@ -1327,6 +1375,9 @@ export default {
 				// folders
 				sum.folders.received = sortAndLimitObject(sumObjects(accountsData.reduce((p,c) => p.concat(c.folders?.received ?? []), [])))
 				sum.folders.sent = sortAndLimitObject(sumObjects(accountsData.reduce((p,c) => p.concat(c.folders?.sent ?? []), [])))
+				// tags
+				sum.tags = sortAndLimitObject(sumObjects(accountsData.reduce((p,c) => p.concat(c.tags ?? []), [])))
+
 				// show summed stats
 				this.display = sum
 
@@ -2135,6 +2186,25 @@ export default {
 						label: this.$t("stats.mailsSent"),
 						data: ds,
 						color: accentColors[0]
+					},
+				],
+				labels: labels
+			}
+		},
+		// prepare data for email tags horizontal bar chart
+		tagsChartData () {
+			const r = sortAndLimitObject(this.display.tags) || {}
+			const color = this.preferences.dark ? accentColors[2] : accentColors[3]
+			let labels = []
+			Object.keys(r).forEach(key => {
+				labels.push(this.tags.find(tag => tag.key === key)?.tag || 'undefined');
+			}, this);
+			return {
+				datasets: [
+					{
+						label: this.$t("stats.mailsPerTag"),
+						data: Object.values(r),
+						borderColor: color
 					},
 				],
 				labels: labels

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -865,6 +865,7 @@ export default {
 				},
 				dark: false,    // preferences loaded from stored options
 				ordinate: true,
+				tagColors: false,
 				startOfWeek: localStartOfWeek(),
 				localIdentities: [],
 				accounts: [],
@@ -979,6 +980,7 @@ export default {
 					// only update those options that changed
 					if (n.dark != o.dark) this.preferences.dark = n.dark
 					if (n.ordinate != o.ordinate) this.preferences.ordinate = n.ordinate
+					if (n.tagColors != o.tagColors) this.preferences.tagColors = n.tagColors
 					if (n.startOfWeek != o.startOfWeek) this.preferences.startOfWeek = n.startOfWeek
 					if (n.addresses != o.addresses) this.preferences.localIdentities = n.addresses.toLowerCase().split(",").map(x => x.trim())
 					if (JSON.stringify(n.accounts) != JSON.stringify(o.accounts)) this.preferences.accounts = n.accounts
@@ -997,6 +999,7 @@ export default {
 			if (result && result.options) {
 				this.preferences.dark = result.options.dark ? true : false
 				this.preferences.ordinate = result.options.ordinate ? true : false
+				this.preferences.tagColors = result.options.tagColors ? true : false
 				this.preferences.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
 				this.preferences.localIdentities = result.options.addresses ? result.options.addresses.toLowerCase().split(",").map(x => x.trim()) : []
 				this.preferences.accounts = result.options.accounts ? result.options.accounts : []
@@ -1207,7 +1210,7 @@ export default {
 				data.folders[type][f]++
 			}
 			// tags
-			m.tags.forEach(t => {
+			m.tags.forEach(tag => {
 				if (!(tag in data.tags)) {
 					data.tags[tag] = 1
 				} else {
@@ -2195,16 +2198,17 @@ export default {
 		tagsChartData () {
 			const r = sortAndLimitObject(this.display.tags) || {}
 			const color = this.preferences.dark ? accentColors[2] : accentColors[3]
-			let labels = []
+			const labels = [], colors = [];
 			Object.keys(r).forEach(key => {
 				labels.push(this.tags.find(tag => tag.key === key)?.tag || 'undefined');
+				colors.push(this.tags.find(tag => tag.key === key)?.color || color);
 			}, this);
 			return {
 				datasets: [
 					{
 						label: this.$t("stats.mailsPerTag"),
 						data: Object.values(r),
-						borderColor: color
+						borderColor: this.preferences.tagColors ? colors : color
 					},
 				],
 				labels: labels

--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -38,7 +38,11 @@ export default {
 				d.backgroundColor = context => {
 					const { ctx, chartArea } = context.chart;
 					if (!chartArea) return null;
-					return transparentGradientBar(ctx, chartArea, d.borderColor, this.horizontal);
+					return transparentGradientBar(ctx,
+						chartArea,
+						Array.isArray(d.borderColor) ? d.borderColor[context.dataIndex] : d.borderColor,
+						this.horizontal
+					);
 				}
 			})
 			return datasets


### PR DESCRIPTION
## Description of the Change

This change creates an additional chart section for charts about tags. It adds an horizontal chart bar showing the number of emails the corresponding tag is used with. It also adds an option to show the tag bars in their corresponding color, that has been configured in Thunderbird. This is deactivated per default.

## Benefits

Tag stats for users utilizing tags to organize their emails:
![image](https://user-images.githubusercontent.com/5441654/125390604-72cacd80-e3a3-11eb-886e-7a24a1f148c7.png)

Option to activate tag colors:
![image](https://user-images.githubusercontent.com/5441654/125390710-9beb5e00-e3a3-11eb-9b37-b6f50bfdb35f.png)

Tag stats in their corresponding colors:
![image](https://user-images.githubusercontent.com/5441654/125390647-837b4380-e3a3-11eb-88f0-b0085005a35f.png)


## Applicable Issues

Closes #328 
