### PR TITLE
🔨 show tooltip when mouse intersects with bar

### DIFF
--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -89,6 +89,12 @@ export default {
 							},
 							beginAtZero: true
 						}
+					},
+					plugins: {
+						tooltip: {
+							intersect: true,
+							position: 'nearest'
+						}
 					}
 				}
 			})


### PR DESCRIPTION
## Description of the Change

This changes the tooltip interaction mode for bar charts. A tooltip is now always shown on a bar, if the cursor intersects with it.

## Benefits

No weird positioning glitches especially on horizontal bar chart tooltips anymore.

![image](https://user-images.githubusercontent.com/5441654/125392277-28971b80-e3a6-11eb-88cc-b6ddbc58b3f8.png)

## Applicable Issues

Closes #327 
