### PR TITLE
Merge similar metrics for email counts

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -94,8 +94,10 @@
       "day": "d",
       "hour": "h",
       "minute": "min",
+      "month": "M",
       "quarter": "Q",
-      "second": "s"
+      "second": "s",
+      "year": "Y"
     },
     "account": "Account",
     "accountEmpty": "This account is empty, no emails here.",
@@ -172,6 +174,9 @@
     "mailsPerDay": "Mails per day",
     "mailsPerMonth": "Mails per month",
     "mailsPerTag": "Mails per tag",
+    "mailsPerQuarter": "Mails per quarter",
+    "mailsPerWeek": "Mails per week",
+    "mailsPerYear": "Mails per year",
     "mailsReceived": "Mails received",
     "mailsSent": "Mails sent",
     "mailsTotal": "Mails total",

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -230,7 +230,7 @@
 						<div class="text-gray">{{ $t("stats.mailsPerDay") }}</div>
 						<div class="featured">{{ perDay }}</div>
 					</div>
-					<div class="text-mono d-flex justify-center">
+					<div class="d-flex justify-center">
 						<div class="d-inline-flex align-center cursor-pointer" @click.prevent="previousNumbersUnit()">
 							<svg class="icon icon-small icon-bold icon-gray-alt icon-hover-accent" viewBox="0 0 24 24">
 								<path stroke="none" d="M0 0h24v24H0z" fill="none" />
@@ -239,39 +239,44 @@
 						</div>
 						<div class="d-inline-flex">
 							<span
-								class="cursor-pointer p-0-25 text-hover-accent2"
+								class="cursor-pointer p-0-25 text-hover-accent2 tooltip tooltip-bottom"
 								:class="{ 'text-gray': !tabs.numbers.years }"
+								:data-tooltip="$t('stats.mailsPerYear')"
 								@click="activateTab('numbers', 'years')"
 							>
-								{{ $t("stats.abbreviations.year") }}
+								<span class="text-mono">{{ $t("stats.abbreviations.year") }}</span>
 							</span>
 							<span
-								class="cursor-pointer p-0-25 text-hover-accent2"
+								class="cursor-pointer p-0-25 text-hover-accent2 tooltip tooltip-bottom"
 								:class="{ 'text-gray': !tabs.numbers.quarters }"
+								:data-tooltip="$t('stats.mailsPerQuarter')"
 								@click="activateTab('numbers', 'quarters')"
 							>
-								{{ $t("stats.abbreviations.quarter") }}
+								<span class="text-mono">{{ $t("stats.abbreviations.quarter") }}</span>
 							</span>
 							<span
-								class="cursor-pointer p-0-25 text-hover-accent2"
+								class="cursor-pointer p-0-25 text-hover-accent2 tooltip tooltip-bottom"
 								:class="{ 'text-gray': !tabs.numbers.months }"
+								:data-tooltip="$t('stats.mailsPerMonth')"
 								@click="activateTab('numbers', 'months')"
 							>
-								{{ $t("stats.abbreviations.month") }}
+								<span class="text-mono">{{ $t("stats.abbreviations.month") }}</span>
 							</span>
 							<span
-								class="cursor-pointer p-0-25 text-hover-accent2"
+								class="cursor-pointer p-0-25 text-hover-accent2 tooltip tooltip-bottom"
 								:class="{ 'text-gray': !tabs.numbers.weeks }"
+								:data-tooltip="$t('stats.mailsPerWeek')"
 								@click="activateTab('numbers', 'weeks')"
 							>
-								{{ $t("stats.abbreviations.calendarWeek") }}
+								<span class="text-mono">{{ $t("stats.abbreviations.calendarWeek") }}</span>
 							</span>
 							<span
-								class="cursor-pointer p-0-25 text-hover-accent2"
+								class="cursor-pointer p-0-25 text-hover-accent2 tooltip tooltip-bottom"
 								:class="{ 'text-gray': !tabs.numbers.days }"
+								:data-tooltip="$t('stats.mailsPerDay')"
 								@click="activateTab('numbers', 'days')"
 							>
-								{{ $t("stats.abbreviations.day") }}
+								<span class="text-mono">{{ $t("stats.abbreviations.day") }}</span>
 							</span>
 						</div>
 						<div class="d-inline-flex align-center cursor-pointer" @click.prevent="nextNumbersUnit()">

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -198,6 +198,8 @@ for m, c in mode
 	margin-bottom: 6rem
 .m-0-auto
 	margin: 0 auto
+.p-0-25
+	padding: .25rem
 .p-0-5
 	padding: .5rem
 .p-1
@@ -252,6 +254,8 @@ for m, c in mode
 	flex-wrap: wrap
 .justify-space-between
 	justify-content: space-between
+.justify-center
+	justify-content: center
 .align-stretch
 	align-self: stretch
 .align-center


### PR DESCRIPTION
## Description of the Change

This change merges two sections about email counts in the featured numbers bar into one section with a small tab/arrow navigation. It also features an additional unit _mails per quarter_.

![image](https://user-images.githubusercontent.com/5441654/126997770-825891e6-af6e-492a-805c-b9d77a3ca2fd.png)

## Benefits

One place for the same metric with just different units, freeing up space for a different metric.

## Applicable Issues

Closes #336 
