### PR TITLE
Unify page titles

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -192,6 +192,7 @@
     "percentOfTotal": "{0}% of total",
     "starAndImprove": "Be a star, fork me on <a href='{0}' target='_blank'>GitHub</a>.",
     "timePeriod": "Date range",
+    "title": "Statistics",
     "tooltips": {
       "clear": "Clear selection",
       "comparison": "Compare accounts in one chart",

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -14,7 +14,7 @@
 			<header id="header">
 				<h1 class="mr-2 d-flex align-items-center">
 					<img class="logo mr-1" :src="`${publicPath}icon.svg`" alt="ThirdStats Logo">
-					Th<span class="text-gray">underb</span>ird Stats
+					{{ $t("stats.title") }}
 				</h1>
 				<!-- filter area -->
 				<div class="filter d-flex flex-wrap gap-1">


### PR DESCRIPTION
## Description of the Change

This small change makes the stats page title appear just like the options page in format: ThirdStats logo + h1 general page title.

![image](https://user-images.githubusercontent.com/5441654/127207739-fb2a6316-3b0a-4db0-884f-9a3368fe920f.png)

## Benefits

Same look and feel for headings on different ThirdStats pages.

## Applicable Issues

None
