### PR TITLE
Live Count Up

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -32,6 +32,11 @@
       "description": "Number of entries shown in charts listing frequent contacts (999 maximum)",
       "label": "Leader Count"
     },
+    "liveCountUp": {
+      "description": "Show live progress of calculated numbers when processing stats data",
+      "info": "Enabling this may increase processing time",
+      "label": "Live Count Up"
+    },
     "localIdentities": {
       "description": "A list of email addresses to recognize as 'sent from' for local accounts",
       "label": "Local Identities"

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -62,6 +62,31 @@
 						</label>
 					</div>
 				</div>
+				<!-- option: live count up -->
+				<div class="entry">
+					<label for="liveCountUp">
+						{{ $t("options.liveCountUp.label") }}
+						<span class="d-block text-gray text-small">{{ $t("options.liveCountUp.description") }}</span>
+					</label>
+					<div class="action">
+						<label class="switch mb-0-5">
+							<input type="checkbox" id="liveCountUp" v-model="options.liveCountUp" />
+							<span class="switch-label" :data-on="$t('options.switch.on')" :data-off="$t('options.switch.off')"></span> 
+							<span class="switch-handle"></span> 
+						</label>
+						<div class="d-flex gap-0-5 align-items-center text-gray">
+							<div>
+								<svg class="icon icon-small text-middle" viewBox="0 0 24 24">
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<line x1="12" y1="8" x2="12.01" y2="8" />
+									<rect x="4" y="4" width="16" height="16" rx="2" />
+									<polyline points="11 12 12 12 12 16 13 16" />
+								</svg>
+							</div>
+							<span class="text-small">{{ $t("options.liveCountUp.info") }}</span>
+						</div>
+					</div>
+				</div>
 			</section>
 			<!-- section related to charts and data retrieval -->
 			<section class="mb-3">
@@ -170,7 +195,7 @@
 						<div class="text-gray text-small">{{ $t("options.selfMessages.description") }}</div>
 					</label>
 					<div class="action d-flex flex-wrap">
-						<select class="flex-grow mb-1" v-model="options.selfMessages" id="selfMessages">
+						<select class="flex-grow mb-0-5" v-model="options.selfMessages" id="selfMessages">
 							<option v-for="val in selfMessagesOptions" :key="val" :value="val">{{ $t("options.selfMessages.values." + val) }}</option>
 						</select>
 						<div class="d-flex gap-0-5 align-items-center text-gray">
@@ -244,7 +269,7 @@
 						<span class="d-block text-gray text-small">{{ $t("options.clearCache.description") }}</span>
 					</label>
 					<div class="action">
-						<button @click="clearCache" class="mb-1">{{ $t("options.clearCache.label") }}</button>
+						<button @click="clearCache" class="mb-0-5">{{ $t("options.clearCache.label") }}</button>
 						<div class="d-flex gap-0-5 align-items-center text-gray">
 							<div>
 								<svg class="icon icon-small text-middle" viewBox="0 0 24 24">
@@ -286,7 +311,7 @@
 						<div class="text-gray text-small">{{ $t("options.resetOptions.description") }}</div>
 					</label>
 					<div class="action">
-						<button @click="resetOptions" class="mb-1">{{ $t("options.resetOptions.label") }}</button>
+						<button @click="resetOptions" class="mb-0-5">{{ $t("options.resetOptions.label") }}</button>
 						<div v-if="options.addresses && options.addresses.length > 0" class="d-flex gap-0-5 align-items-center text-gray">
 							<div>
 								<svg class="icon icon-small text-middle" viewBox="0 0 24 24">
@@ -364,6 +389,7 @@ export default defineComponent({
 			dark = false,
 			ordinate = true,
 			tagColors = false,
+			liveCountUp = true,
 			startOfWeek = -1,
 			addresses = "",
 			accounts = [],
@@ -380,6 +406,7 @@ export default defineComponent({
 					dark: dark === null ? this.options.dark : dark,
 					ordinate: ordinate === null ? this.options.ordinate : ordinate,
 					tagColors: tagColors === null ? this.options.tagColors : tagColors,
+					liveCountUp: liveCountUp === null ? this.options.liveCountUp : liveCountUp,
 					startOfWeek: startOfWeek === null ? this.options.startOfWeek : startOfWeek,
 					addresses: addresses === null ? this.options.addresses : addresses,
 					accounts: accounts === null ? this.options.accounts : accounts,

--- a/src/Popup.vue
+++ b/src/Popup.vue
@@ -136,8 +136,8 @@ export default defineComponent({
 							const r = stored["stats-" + a.id].yearsData.received
 							const s = stored["stats-" + a.id].yearsData.sent
 							let labels = [], d = []
-							const start = new Date(stored["stats-" + a.id].numbers.start)
-							const end = stored["stats-" + a.id].numbers.end ? new Date(stored["stats-" + a.id].numbers.end) : new Date()
+							const start = new Date(stored["stats-" + a.id].meta.start)
+							const end = stored["stats-" + a.id].meta.end ? new Date(stored["stats-" + a.id].meta.end) : new Date()
 							for (let y = start.getFullYear(); y <= end.getFullYear(); ++y) {
 								labels.push(y)
 								d.push((y in r ? r[y] : 0) + (y in s ? s[y] : 0))

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -1024,7 +1024,9 @@ export default defineComponent({
 		initData () {
 			return { 
 				meta: {
-					timestamp: null
+					timestamp: null,
+					start: this.active.period.start ? new Date(this.active.period.start) : new Date(),
+					end: this.active.period.end ? new Date(this.active.period.end) : new Date(),
 				},
 				numbers: {
 					total: 0,
@@ -1035,8 +1037,6 @@ export default defineComponent({
 					tagged: 0,
 					junk: 0,
 					junkScore: 0,
-					start: this.active.period.start ? new Date(this.active.period.start) : new Date(),
-					end: this.active.period.end ? new Date(this.active.period.end) : new Date(),
 				},
 				yearsData: {
 					received: {},
@@ -1238,9 +1238,9 @@ export default defineComponent({
 			if (m.junk) data.numbers.junk++
 			data.numbers.junkScore += m.junkScore
 			// calculate starting date (= date of oldest email)
-			const start = new Date(data.numbers.start)
+			const start = new Date(data.meta.start)
 			if (m.date && m.date.getTime() > 0 && m.date.getTime() < start.getTime()) {
-				data.numbers.start = m.date
+				data.meta.start = m.date
 			}
 			// years
 			const y = m.date.getFullYear()
@@ -1352,6 +1352,7 @@ export default defineComponent({
 					}
 				})
 			}
+			// this.display.numbers = data.numbers;
 		},
 		// check if a contact is involved in a message
 		// = <contact> is either author or recipient, CC or BCC of <message>
@@ -1459,8 +1460,8 @@ export default defineComponent({
 				sum.numbers.tagged = accountsData.reduce((p,c) => p+(c.numbers.tagged ?? 0), 0)
 				sum.numbers.junk = accountsData.reduce((p,c) => p+c.numbers.junk, 0)
 				sum.numbers.junkScore = accountsData.reduce((p,c) => p+c.numbers.junkScore, 0)/accountsData.length
-				sum.numbers.start = accountsData.reduce((p,c) => p < c.numbers.start ? p : c.numbers.start, 0)
-				sum.numbers.end = accountsData.reduce((p,c) => p >= c.numbers.end ? p : c.numbers.end, 0)
+				sum.meta.start = accountsData.reduce((p,c) => p < c.meta.start ? p : c.meta.start, 0)
+				sum.meta.end = accountsData.reduce((p,c) => p >= c.meta.end ? p : c.meta.end, 0)
 				// years
 				accountsData.reduce((p,c) => [...new Set([...p ,...Object.keys(c.yearsData.received)])], [])
 					.map(y => { sum.yearsData.received[y] = accountsData.reduce((p,c) => c.yearsData.received[y] ? p+c.yearsData.received[y] : p, 0) })
@@ -1583,8 +1584,8 @@ export default defineComponent({
 		async updatePeriod () {
 			if (this.validPeriod()) {
 				await this.loadAccount(this.active.account, true)
-				this.display.numbers.start = new Date(this.active.period.start)
-				this.display.numbers.end = new Date(this.active.period.end)
+				this.display.meta.start = new Date(this.active.period.start)
+				this.display.meta.end = new Date(this.active.period.end)
 				this.adjustSelectedYear()
 			}
 		},
@@ -1712,8 +1713,8 @@ export default defineComponent({
 		// corrects selected year, if it's out of the current date range
 		// called after data got reprocessed
 		adjustSelectedYear () {
-			const min = new Date(this.display.numbers.start).getFullYear()
-			const max = new Date(this.display.numbers.end).getFullYear()
+			const min = new Date(this.display.meta.start).getFullYear()
+			const max = new Date(this.display.meta.end).getFullYear()
 			const current = this.preferences.sections.activity.year
 			if (current < min) this.preferences.sections.activity.year = min
 			if (current > max) this.preferences.sections.activity.year = max
@@ -1793,8 +1794,8 @@ export default defineComponent({
 		// number of days from oldest email till today or depending on period filter
 		days () {
 			const oneDay = 24 * 60 * 60 * 1000
-			const start = new Date(this.display.numbers.start)
-			const end = this.display.numbers.end ? new Date(this.display.numbers.end) : new Date()
+			const start = new Date(this.display.meta.start)
+			const end = this.display.meta.end ? new Date(this.display.meta.end) : new Date()
 			return Math.round(Math.abs((start - end) / oneDay))
 		},
 		// number of weeks from oldest email till today
@@ -2441,11 +2442,11 @@ export default defineComponent({
 		},
 		// first date in currently displayed data
 		minDate () {
-			return new Date(this.display.numbers.start)
+			return new Date(this.display.meta.start)
 		},
 		// last date in currently displayed data
 		maxDate () {
-			return this.display.numbers.end ? new Date(this.display.numbers.end) : new Date()
+			return this.display.meta.end ? new Date(this.display.meta.end) : new Date()
 		},
 		// year minDate
 		minYear () {

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -992,6 +992,7 @@ export default defineComponent({
 				dark: false,    // preferences loaded from stored options
 				ordinate: true,
 				tagColors: false,
+				liveCountUp: true,
 				startOfWeek: localStartOfWeek(),
 				localIdentities: [],
 				accounts: [],
@@ -1109,6 +1110,7 @@ export default defineComponent({
 					if (n.dark != o.dark) this.preferences.dark = n.dark
 					if (n.ordinate != o.ordinate) this.preferences.ordinate = n.ordinate
 					if (n.tagColors != o.tagColors) this.preferences.tagColors = n.tagColors
+					if (n.liveCountUp != o.liveCountUp) this.preferences.liveCountUp = n.liveCountUp
 					if (n.startOfWeek != o.startOfWeek) this.preferences.startOfWeek = n.startOfWeek
 					if (n.addresses != o.addresses) this.preferences.localIdentities = n.addresses.toLowerCase().split(",").map(x => x.trim())
 					if (JSON.stringify(n.accounts) != JSON.stringify(o.accounts)) this.preferences.accounts = n.accounts
@@ -1128,6 +1130,7 @@ export default defineComponent({
 				this.preferences.dark = result.options.dark ? true : false
 				this.preferences.ordinate = result.options.ordinate ? true : false
 				this.preferences.tagColors = result.options.tagColors ? true : false
+				this.preferences.liveCountUp = result.options.liveCountUp ? true : false
 				this.preferences.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
 				this.preferences.localIdentities = result.options.addresses ? result.options.addresses.toLowerCase().split(",").map(x => x.trim()) : []
 				this.preferences.accounts = result.options.accounts ? result.options.accounts : []
@@ -1352,7 +1355,8 @@ export default defineComponent({
 					}
 				})
 			}
-			// this.display.numbers = data.numbers;
+			// live update numbers section if corresponding option is enabled
+			if (this.preferences.liveCountUp) this.display.numbers = data.numbers;
 		},
 		// check if a contact is involved in a message
 		// = <contact> is either author or recipient, CC or BCC of <message>


### PR DESCRIPTION
## Description of the Change

An additional option *Live Count Up* is introduced to show live progress of calculated numbers when processing stats data. This is enabled by default.

![thirdstats_live_count_up](https://user-images.githubusercontent.com/5441654/158269509-52ed0918-1833-4d67-9998-82f720606922.gif)

![image](https://user-images.githubusercontent.com/5441654/158269608-602fe6ab-0ba2-4552-b91e-a431a49483bf.png)

## Benefits

Another visual indicator for users to see that stats data is being processed. Users on slower systems can disable this option to speed up stats processing.

## Applicable Issues

Implements #248 
