### PR TITLE
Automatic Processing

### DIFF
--- a/public/_locales/en/messages.json
+++ b/public/_locales/en/messages.json
@@ -13,6 +13,10 @@
       "description": "Enable caching system for faster display of already processed stats data.",
       "label": "Activate Cache"
     },
+    "autoRefresh": {
+      "description": "Enable automatic reprocessing of the stats data in the background. Set a time interval in minutes (minimum of 5).",
+      "label": "Automatic Processing"
+    },
     "clearCache": {
       "description": "Remove all cached stats data from all accounts. Will be rebuild on opening the stats page again.",
       "empty": "Cache is empty",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,7 +9,7 @@
 	"applications": {
 		"gecko": {
 			"id": "thirdstats@devmount.de",
-			"strict_min_version": "78.0"
+			"strict_min_version": "91.0"
 		}
 	},
 	"browser_action": {

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -123,12 +123,12 @@
 								/>
 							</div>
 							<div class="d-flex flex-direction-column button-group-vertical">
-								<button @click="options.autoRefreshInterval++" class="h-1-25 py-0 px-0-5">
+								<button @click="incrementAutoRefreshInterval()" class="h-1-25 py-0 px-0-5">
 									<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">
 										<polyline points="6,12 12,6 18,12" />
 									</svg>
 								</button>
-								<button @click="options.autoRefreshInterval > 5 ? options.autoRefreshInterval-- : null" class="h-1-25 py-0 px-0-5">
+								<button @click="decrementAutoRefreshInterval()" class="h-1-25 py-0 px-0-5">
 									<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">
 										<polyline points="6,5 12,11 18,5" />
 									</svg>
@@ -279,7 +279,16 @@
 						<div class="text-gray text-small">{{ $t("options.leaderCount.description") }}</div>
 					</label>
 					<div class="action d-flex input-group">
-						<input class="flex-grow" type="number" v-model="options.leaderCount" placeholder="20" min="1" max="999" id="leaderCount" />
+						<input
+							class="flex-grow"
+							id="leaderCount"
+							type="number"
+							v-model="options.leaderCount"
+							placeholder="20"
+							min="1"
+							max="999"
+							@change="checkLeaderCount()"
+						/>
 						<div class="d-flex flex-direction-column button-group-vertical">
 							<button @click="incrementLeaderCount()" class="h-1-25 py-0 px-0-5">
 								<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">
@@ -530,6 +539,22 @@ export default defineComponent({
 			await messenger.storage.local.set({ options: { addresses: addresses } })
 			this.options.addresses = addresses
 		},
+		// increases auto refresh interval up without limit
+		incrementAutoRefreshInterval () {
+			this.options.autoRefreshInterval++;
+		},
+		// decreases auto refresh interval down to limit 5
+		decrementAutoRefreshInterval () {
+			if (this.options.autoRefreshInterval > 5) {
+				this.options.autoRefreshInterval--
+			}
+		},
+		// check auto refresh number input to stay in allowed range
+		checkAutoRefreshInterval () {
+			if (this.options.autoRefreshInterval < 5) {
+				this.options.autoRefreshInterval = 5;
+			}
+		},
 		// increases leader count up to limit 999
 		incrementLeaderCount () {
 			if (this.options.leaderCount < 999) {
@@ -542,10 +567,13 @@ export default defineComponent({
 				this.options.leaderCount--
 			}
 		},
-		// check auto refresh number input to stay in allowed range
-		checkAutoRefreshInterval () {
-			if (this.options.autoRefreshInterval < 5) {
-				this.options.autoRefreshInterval = 5;
+		// check leader count input to stay in allowed range
+		checkLeaderCount () {
+			if (this.options.leaderCount < 1) {
+				this.options.leaderCount = 1;
+			}
+			if (this.options.leaderCount > 999) {
+				this.options.leaderCount = 999;
 			}
 		},
 		// clear all cached stats entries

--- a/src/Options.vue
+++ b/src/Options.vue
@@ -87,6 +87,56 @@
 						</div>
 					</div>
 				</div>
+				<!-- option: auto processing -->
+				<div class="entry">
+					<label for="autoRefresh">
+						<div class="d-flex align-items-end gap-0-5">
+							{{ $t("options.autoRefresh.label") }}
+							<span class="tooltip text-gray mb--0-25" :data-tooltip="$t('options.note.reloadWindowRequired')">
+								<svg class="icon icon-tiny" viewBox="0 0 24 24">
+									<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+									<path d="M20 11a8.1 8.1 0 0 0 -15.5 -2m-.5 -4v4h4" />
+									<path d="M4 13a8.1 8.1 0 0 0 15.5 2m.5 4v-4h-4" />
+									<line x1="12" y1="9" x2="12" y2="12" />
+									<line x1="12" y1="15" x2="12.01" y2="15" />
+								</svg>
+							</span>
+						</div>
+						<div class="text-gray text-small">{{ $t("options.autoRefresh.description") }}</div>
+					</label>
+					<div class="action d-flex align-items-center gap-1">
+						<label class="switch flex-no-shrink">
+							<input type="checkbox" id="autoRefresh" v-model="options.autoRefresh" />
+							<span class="switch-label" :data-on="$t('options.switch.on')" :data-off="$t('options.switch.off')"></span> 
+							<span class="switch-handle"></span> 
+						</label>
+						<div v-if="options.autoRefresh" class="action d-flex flex-grow input-group">
+							<div class="d-flex flex-grow" :data-unit="$t('stats.abbreviations.minute')">
+								<input
+									class="flex-grow"
+									id="autoRefreshInterval"
+									type="number"
+									v-model="options.autoRefreshInterval"
+									placeholder="30"
+									min="5"
+									@change="checkAutoRefreshInterval()"
+								/>
+							</div>
+							<div class="d-flex flex-direction-column button-group-vertical">
+								<button @click="options.autoRefreshInterval++" class="h-1-25 py-0 px-0-5">
+									<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">
+										<polyline points="6,12 12,6 18,12" />
+									</svg>
+								</button>
+								<button @click="options.autoRefreshInterval > 5 ? options.autoRefreshInterval-- : null" class="h-1-25 py-0 px-0-5">
+									<svg class="icon icon-small icon-bold d-block m-0-auto" viewBox="0 0 24 20">
+										<polyline points="6,5 12,11 18,5" />
+									</svg>
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
 			</section>
 			<!-- section related to charts and data retrieval -->
 			<section class="mb-3">
@@ -166,7 +216,7 @@
 					</label>
 					<div class="action">
 						<div v-for="(a, i) in allAccounts" :key="i" class="d-flex justify-space-between">
-							<label class="checkbox cursor-pointer text-overflow-ellipsis flex-dont-grow">
+							<label class="checkbox cursor-pointer text-overflow-ellipsis flex-no-grow">
 								<input type="checkbox" :value="a.id" v-model="options.accounts" />
 								<i class="checkbox-icon"></i> {{ a.name }}
 							</label>
@@ -390,6 +440,8 @@ export default defineComponent({
 			ordinate = true,
 			tagColors = false,
 			liveCountUp = true,
+			autoRefresh = true,
+			autoRefreshInterval = 30,
 			startOfWeek = -1,
 			addresses = "",
 			accounts = [],
@@ -407,6 +459,8 @@ export default defineComponent({
 					ordinate: ordinate === null ? this.options.ordinate : ordinate,
 					tagColors: tagColors === null ? this.options.tagColors : tagColors,
 					liveCountUp: liveCountUp === null ? this.options.liveCountUp : liveCountUp,
+					autoRefresh: autoRefresh === null ? this.options.autoRefresh : autoRefresh,
+					autoRefreshInterval: autoRefreshInterval === null ? this.options.autoRefreshInterval : autoRefreshInterval,
 					startOfWeek: startOfWeek === null ? this.options.startOfWeek : startOfWeek,
 					addresses: addresses === null ? this.options.addresses : addresses,
 					accounts: accounts === null ? this.options.accounts : accounts,
@@ -486,6 +540,12 @@ export default defineComponent({
 		decrementLeaderCount () {
 			if (this.options.leaderCount > 1) {
 				this.options.leaderCount--
+			}
+		},
+		// check auto refresh number input to stay in allowed range
+		checkAutoRefreshInterval () {
+			if (this.options.autoRefreshInterval < 5) {
+				this.options.autoRefreshInterval = 5;
 			}
 		},
 		// clear all cached stats entries

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -1546,7 +1546,7 @@ export default defineComponent({
 				sum.tags = sortAndLimitObject(sumObjects(accountsData.reduce((p,c) => p.concat(c.tags ?? []), [])))
 
 				// show summed stats or keep current view if processing was invoked automatically
-				this.display = auto ? accountsData[displayedAccountKey] : sum;
+				this.display = auto && displayedAccountKey ? accountsData[displayedAccountKey] : sum;
 
 				// retrieve all values of account objects for comparison views
 				let comparison = JSON.parse(JSON.stringify(this.initComparisonData()))
@@ -1567,9 +1567,6 @@ export default defineComponent({
 					comparison.monthData[a.id] = sumObjects([accountsData[i].monthData.received, accountsData[i].monthData.sent])
 				})
 				this.comparison = comparison
-
-				// finally adjust displayed activity year
-				this.adjustSelectedYear()
 			} else {
 				// load single account from id
 				const account = await messenger.accounts.get(id)
@@ -1590,10 +1587,10 @@ export default defineComponent({
 					this.progress.current = 0
 					this.progress.max = 0
 				}
-				// adjust displayed activity year
-				this.adjustSelectedYear()
 			}
-			// stop loading indication
+			// finally adjust displayed activity year
+			this.adjustSelectedYear()
+			// finished - stop loading indication
 			this.loading = false
 		},
 		// reset folder filter

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -1018,6 +1018,10 @@ export default defineComponent({
 		await this.getTags()
 		// retrieve all accounts
 		await this.getAccounts()
+		// start auto-processing in intervals
+		setInterval(() => {
+			this.loadAccount('sum', true);
+		}, 60 * 1000);
 	},
 	methods: {
 		// basic data structure to display numbers and charts
@@ -1393,7 +1397,7 @@ export default defineComponent({
 			return true
 		},
 		// retrieve and process data of account with <id=accountId>
-		// or of multiple accounts with <id=sum>
+		// gets called multiple times if processing was invoked for all accounts
 		async refresh (id) {
 			// get currently selected account
 			const account = await messenger.accounts.get(id)

--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -993,6 +993,8 @@ export default defineComponent({
 				ordinate: true,
 				tagColors: false,
 				liveCountUp: true,
+				autoRefresh: true,
+				autoRefreshInterval: 30,
 				startOfWeek: localStartOfWeek(),
 				localIdentities: [],
 				accounts: [],
@@ -1019,11 +1021,13 @@ export default defineComponent({
 		// retrieve all accounts
 		await this.getAccounts()
 		// start auto-processing in intervals
-		setInterval(() => {
-			if (!this.loading) {
-				this.loadAccount('sum', true, true);
-			}
-		}, 60 * 1000);
+		if (this.preferences.autoRefresh) {
+			setInterval(() => {
+				if (!this.loading) {
+					this.loadAccount('sum', true, true);
+				}
+			}, Number(this.preferences.autoRefreshInterval) * 60 * 1000);
+		}
 	},
 	methods: {
 		// basic data structure to display numbers and charts
@@ -1117,6 +1121,8 @@ export default defineComponent({
 					if (n.ordinate != o.ordinate) this.preferences.ordinate = n.ordinate
 					if (n.tagColors != o.tagColors) this.preferences.tagColors = n.tagColors
 					if (n.liveCountUp != o.liveCountUp) this.preferences.liveCountUp = n.liveCountUp
+					if (n.autoRefresh != o.autoRefresh) this.preferences.autoRefresh = n.autoRefresh
+					if (n.autoRefreshInterval != o.autoRefreshInterval) this.preferences.autoRefreshInterval = n.autoRefreshInterval
 					if (n.startOfWeek != o.startOfWeek) this.preferences.startOfWeek = n.startOfWeek
 					if (n.addresses != o.addresses) this.preferences.localIdentities = n.addresses.toLowerCase().split(",").map(x => x.trim())
 					if (JSON.stringify(n.accounts) != JSON.stringify(o.accounts)) this.preferences.accounts = n.accounts
@@ -1137,6 +1143,8 @@ export default defineComponent({
 				this.preferences.ordinate = result.options.ordinate ? true : false
 				this.preferences.tagColors = result.options.tagColors ? true : false
 				this.preferences.liveCountUp = result.options.liveCountUp ? true : false
+				this.preferences.autoRefresh = result.options.autoRefresh ? true : false
+				this.preferences.autoRefreshInterval = result.options.autoRefreshInterval ? result.options.autoRefreshInterval : 30
 				this.preferences.startOfWeek = result.options.startOfWeek ? result.options.startOfWeek : 0
 				this.preferences.localIdentities = result.options.addresses ? result.options.addresses.toLowerCase().split(",").map(x => x.trim()) : []
 				this.preferences.accounts = result.options.accounts ? result.options.accounts : []

--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -232,6 +232,8 @@ for m, c in mode
 	padding-bottom: 6rem
 .gap-0-5
 	gap: .5rem
+.gap-1
+	gap: 1rem
 .w-6
 	width: 6rem
 .w-available
@@ -254,8 +256,10 @@ for m, c in mode
 	flex-direction: column
 .flex-grow
 	flex-grow: 1
-.flex-dont-grow
+.flex-no-grow
 	flex-grow: 0
+.flex-no-shrink
+	flex-shrink: 0
 .flex-wrap
 	flex-wrap: wrap
 .justify-space-between
@@ -477,6 +481,15 @@ input[type=color]
 		.{m} &:active::-moz-color-swatch,
 		.{m} &:focus::-moz-color-swatch
 			box-shadow: 0 0 0 .25rem rgba(c.gray1, .2)
+[data-unit]
+	position: relative
+	&::after
+		position: absolute
+		content: attr(data-unit)
+		right: .5rem
+		top: 50%
+		transform: translateY(-50%)
+		z-index: 50
 
 .checkbox
 	display: block


### PR DESCRIPTION
## Description of the Change

This change introduces automatic processing of stats data in a defined time interval. A corresponding add-on option provides the possibility to disable/enable automatic processing and set a number of minutes for the time interval. The default value is enabled with 30 minutes. If this option is changed, the stats tab needs to be reloaded.

![image](https://user-images.githubusercontent.com/5441654/159565470-8d493bda-4860-4273-96e7-27377da1129f.png)

Automatic processing only happens when the stats page is open. Reprocessing is always done for all active accounts. The current view (selected account option or filter) is kept during and after reprocessing. Live-Update of featured numbers is disabled for automatic processing. The time the data was updated is shown in the upper left as usual - with automatic processing enabled, the data shouldn't be older than the defined time interval anymore.

The strict minimum Thunderbird version for this add-on is now 91.

Also a bug was fixed where it was possible to set a number out of permitted range for the leader count option.

## Benefits

This reduces the need to manually reprocess data to keep it up to date.

## Applicable Issues

Implementes #348 
