### PR TITLE
Support for Spaces Toolbar

### DIFF
--- a/public/js/background.js
+++ b/public/js/background.js
@@ -1,4 +1,19 @@
-// nothing here yet
-// this script serves as a dummy to create a background page as a workaround to retrieve account list on options page
-// see https://thunderbird.topicbox.com/groups/addons/Te33a79990d7a857e
-// see https://github.com/thundernest/developer-docs/blob/master/add-ons/updating/tb78/README.md#replacing-options
+// this script holds all background activity not related to stats building
+
+function main() {
+  // add icon to spaces toolbar
+  if (messenger.spacesToolbar) {
+    messenger.spacesToolbar.addButton(
+      'third_stats',
+      {
+        badgeBackgroundColor: '#e64db9',
+        badgeText: '',
+        defaultIcons: '',
+        title: 'ThirdStats',
+        url: '../stats.html?s=sum'
+      }
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change adds a ThirdStats button to the Spaces Toolbar of Thunderbird:

![image](https://user-images.githubusercontent.com/5441654/193858066-6abd241d-7bec-4ce9-89bb-b9ef2fff7014.png)
![image](https://user-images.githubusercontent.com/5441654/193858202-58b8bd09-3a20-4301-be94-b93ae78fa30c.png)

When clicking the button, the stats page opens or the already opened tab gets active.

## Benefits

Easier access to the stats page

## Applicable Issues

Implements #382 
