### PR TITLE
Add-on icon depending on theme

### DIFF
--- a/public/icon-dark.svg
+++ b/public/icon-dark.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="none" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z"/>
+  <polyline style="stroke:#18181b" points="4 19 8 13 12 15 16 10 20 14 20 19 4 19"/>
+  <polyline style="stroke:#18181b" points="4 12 7 8 11 10 16 4 20 8"/>
+</svg>

--- a/public/icon-light.svg
+++ b/public/icon-light.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="none" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z"/>
+  <polyline style="stroke:#fafafa" points="4 19 8 13 12 15 16 10 20 14 20 19 4 19"/>
+  <polyline style="stroke:#fafafa" points="4 12 7 8 11 10 16 4 20 8"/>
+</svg>

--- a/public/js/background.js
+++ b/public/js/background.js
@@ -8,7 +8,19 @@ function main() {
       {
         badgeBackgroundColor: '#e64db9',
         badgeText: '',
-        defaultIcons: '',
+        defaultIcons: '../icon.svg',
+        themeIcons: [
+          {
+            dark: '../icon-dark.svg',
+            light: '../icon-light.svg',
+            size: 16
+          },
+          {
+            dark: '../icon-dark.svg',
+            light: '../icon-light.svg',
+            size: 32
+          }
+        ],
         title: 'ThirdStats',
         url: '../stats.html'
       }


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

The ThirdStats icon in the spaces toolbar now matches the current theme mode.

## Benefits

The icon now better integrates into the spaces toolbar:

![thirdstats_icon_light](https://user-images.githubusercontent.com/5441654/227700378-a35d6117-cd74-41ad-aeb6-1ea9638a417b.png)
![thirdstats_icon_dark](https://user-images.githubusercontent.com/5441654/227700380-ebee21da-6a6a-4eed-90c7-ebe48ceb3431.png)


## Applicable Issues

#382 
