### PR TITLE
Fix form select appearance

### DIFF
--- a/src/assets/global.styl
+++ b/src/assets/global.styl
@@ -344,10 +344,10 @@ for m, c in mode
 	&.icon-huge
 		width: 10rem
 		height: 10rem
-	
+
 	&.icon-thin
 		stroke-width: 1
-	
+
 	&.icon-bold
 		stroke-width: 2
 
@@ -441,7 +441,6 @@ button, .btn
 			box-shadow: 0 0 0 .25rem rgba(c.accent1, .2)
 
 select
-	appearance: none
 	border: solid 1px
 	border-radius: 2px
 	color: inherit
@@ -449,6 +448,7 @@ select
 	outline: none
 	box-sizing: content-box
 	transition: all transition.duration transition.function
+	height: 1.5rem
 	&.disabled
 		cursor: not-allowed
 	&:focus
@@ -456,7 +456,7 @@ select
 	for m, c in mode
 		.{m} &
 			color: c.front
-			background: c.back url("data:image/svg+xml;charset=utf8,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%204%205%22%3E%3Cpath%20fill=%22%23" substr(s("%s", c.gray2),1,6) "%22%20d=%22M2%200L0%202h4zm0%205L0%203h4z%22/%3E%3C/svg%3E") no-repeat right .5em center / .6em .75em
+			background: c.back
 			border-color: c.gray2
 		.{m} &:hover:not(.disabled)
 			border-color: c.gray1


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change restores select inputs native appearance, since height and arrow indicators were broken somehow.

## Benefits

UI improvement.

## Applicable Issues
None
