### PR TITLE
Replace Twitter by Mastodon share link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Contributions are very welcome! See the [Contribution Guidelines](./.github/CONT
 
 - [Give this project a star](https://github.com/devmount/third-stats/stargazers) on GitHub ⭐
 - [Write a short review](https://addons.thunderbird.net/en-US/thunderbird/addon/thirdstats/#reviews) on addons.thunderbird.net (ATN) ✏
-- [Tweet it](https://twitter.com/intent/tweet?text=ThirdStats%20-%20a%20Thunderbird%20add-on%20for%20beautifully%20visualized%20email%20account%20stats%20by%20%40devmount%20%23thunderbird%20%23statistics%20https://addons.thunderbird.net/thunderbird/addon/thirdstats) 💬
+- [Share it](https://mastodonshare.com/?text=ThirdStats%20-%20Beautifully%20visualized%20statistics%20for%20your%20Thunderbird%20Email%20Accounts%20%40devmount%40mstdn.io%20%23thunderbird&url=https://addons.thunderbird.net/thunderbird/addon/thirdstats) 💬
 - Tell your friends and colleagues to try ThirdStats 💬
 
 ### Become a tester

--- a/src/parts/ProjectMeta.vue
+++ b/src/parts/ProjectMeta.vue
@@ -27,7 +27,8 @@
 			>
 				<svg class="icon icon-tiny icon-accent2" viewBox="0 0 24 24">
 					<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
-					<path d="M22 4.01c-1 .49 -1.98 .689 -3 .99c-1.121 -1.265 -2.783 -1.335 -4.38 -.737s-2.643 2.06 -2.62 3.737v1c-3.245 .083 -6.135 -1.395 -8 -4c0 0 -4.182 7.433 4 11c-1.872 1.247 -3.739 2.088 -6 2c3.308 1.803 6.913 2.423 10.034 1.517c3.58 -1.04 6.522 -3.723 7.651 -7.742a13.84 13.84 0 0 0 .497 -3.753c-.002 -.249 1.51 -2.772 1.818 -4.013z" />
+					<path d="M18.648 15.254c-1.816 1.763 -6.648 1.626 -6.648 1.626a18.262 18.262 0 0 1 -3.288 -.256c1.127 1.985 4.12 2.81 8.982 2.475c-1.945 2.013 -13.598 5.257 -13.668 -7.636l-.026 -1.154c0 -3.036 .023 -4.115 1.352 -5.633c1.671 -1.91 6.648 -1.666 6.648 -1.666s4.977 -.243 6.648 1.667c1.329 1.518 1.352 2.597 1.352 5.633s-.456 4.074 -1.352 4.944z" />
+					<path d="M12 11.204v-2.926c0 -1.258 -.895 -2.278 -2 -2.278s-2 1.02 -2 2.278v4.722m4 -4.722c0 -1.258 .895 -2.278 2 -2.278s2 1.02 2 2.278v4.722" />
 				</svg>
 				<span v-if="!compact">{{ t('cta.share') }}</span>
 			</a>
@@ -91,7 +92,7 @@ const version = inject('version');
 
 const links = {
 	donate:    'https://paypal.me/devmount',
-	share:     'https://twitter.com/intent/tweet?text=ThirdStats%20-%20a%20Thunderbird%20add-on%20for%20beautifully%20visualized%20email%20account%20stats%20by%20%40devmount%20%23thunderbird%20%23statistics%20https://addons.thunderbird.net/thunderbird/addon/thirdstats',
+	share:     'https://mastodonshare.com/?text=ThirdStats%20-%20' + t('extensionDescription.message') + '%20%40devmount%40mstdn.io%20%23thunderbird&url=https://addons.thunderbird.net/thunderbird/addon/thirdstats',
 	star:      'https://github.com/devmount/third-stats/stargazers',
 	review:    'https://addons.thunderbird.net/thunderbird/addon/thirdstats/#reviews',
 	translate: 'https://github.com/devmount/third-stats/issues/343',


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

Since Twitter is a thing of the past, this change replaces Twitter links by a Mastodon forwarder. I could have implemented a Mastodon server selector but, well... I went the easy way there, don't blame me.

