### PR TITLE
Set autoSkipPadding for bar charts to zero

### DIFF
--- a/src/charts/BarChart.vue
+++ b/src/charts/BarChart.vue
@@ -107,6 +107,7 @@ const draw = () => {
 					ticks: {
 						maxRotation: 0,
 						padding: props.horizontal ? 0 : 10,
+						autoSkipPadding: 0,
 					},
 					beginAtZero: true,
 				}


### PR DESCRIPTION
<!--
* Filling out the template is required.
* All new code must have been tested to ensure against regressions
-->

## Description of the Change

This change removes the auto skip padding for axis labels completely. This way, there is still no overlapping of entries, but more labels will be shown for horizontal bar charts. With the current height of bar charts there can be 24 entries without skip:

<img width="598" height="467" alt="image" src="https://github.com/user-attachments/assets/598fb565-9088-45f8-a9ef-284adf570710" />


## Benefits

Hopefully better UX.

## Applicable Issues

Closes #433 