### PR TITLE
fix: correct heatmap year filtering

### DIFF
--- a/src/Stats.vue
+++ b/src/Stats.vue
@@ -2253,15 +2253,29 @@ const monthComparedChartData = computed(() => {
 
 // prepare data for single date matrix charts
 const dateChartData = computed(() => {
-	const end = startOfToday();
-	let rd = Object.entries(display.value.dateData ? display.value.dateData.received : []);
-	let r = preferences.sections.activity.year == (new Date().getFullYear())
-		? rd.filter(e => new Date(e[0]) > new Date(new Date().setYear(end.getFullYear() - 1)))
-		: rd.filter(e => e[0].substring(0,4) == preferences.sections.activity.year);
-	let sd = Object.entries(display.value.dateData ? display.value.dateData.sent : []);
-	let s = preferences.sections.activity.year == (new Date().getFullYear())
-		? sd.filter(e => new Date(e[0]) > new Date(new Date().setYear(end.getFullYear() - 1)))
-		: sd.filter(e => e[0].substring(0,4) == preferences.sections.activity.year);
+	const year = preferences.sections.activity.year;
+	// Generate all dates for the full year (Jan 1 to Dec 31)
+	const startDate = new Date(year, 0, 1);
+	const endDate = new Date(year, 11, 31);
+
+	// Build lookup maps from actual data
+	const receivedMap = Object.fromEntries(
+		Object.entries(display.value.dateData?.received || {})
+			.filter(e => e[0].substring(0, 4) == year)
+	);
+	const sentMap = Object.fromEntries(
+		Object.entries(display.value.dateData?.sent || {})
+			.filter(e => e[0].substring(0, 4) == year)
+	);
+
+	// Generate full year data with 0 for empty days
+	let r = [], s = [];
+	for (let d = new Date(startDate); d <= endDate; d.setDate(d.getDate() + 1)) {
+		const key = d.toISOString().slice(0, 10);
+		r.push([key, receivedMap[key] || 0]);
+		s.push([key, sentMap[key] || 0]);
+	}
+
 	// TODO: handle options.startOfWeek
 	return {
 		received: { label: t("stats.mailsReceived"), data: r },


### PR DESCRIPTION
- Fixed bug where current year showed data from previous year
- Fixed months displaying in wrong order
- Now displays full year grid with only active days colored

Fixes Issue #488